### PR TITLE
support passing credentials via constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ $ echo "API_USERNAME='YOUR_ENDPOINT_NAME'" >> .env
 $ echo ".env" >> .gitignore
 ```
 
+Or pass them as parameters when creating emailService
+
+```javascript
+const pbMail = require('paubox-node');
+const pauboxConfig = {
+  apiUsername: 'your-api-username',
+  apiKey: 'your-api-key',
+};
+const service = pbMail.emailService(pauboxConfig);
+```
+
 <a name="#usage"></a>
 ## Usage
 

--- a/lib/service/emailService.js
+++ b/lib/service/emailService.js
@@ -9,17 +9,22 @@ var _getAuthheader = Symbol('getAuthheader');
 var _convertMsgObjtoJSONReqObj = Symbol('convertMsgObjtoJSONReqObj');
 
 var emailService = function () {
-  function emailService() {
+  function emailService(config) {
     _classCallCheck(this, emailService);
 
-    if (!process.env.API_KEY) {
+    config = Object.assign({
+      apiUsername: process.env.API_USERNAME,
+      apiKey: process.env.API_KEY,
+    }, config);
+
+    if (!config.apiKey) {
       throw new Error("apiKey is missing.");
     }
-    if (!process.env.API_USERNAME) {
+    if (!config.apiUsername) {
       throw new Error("apiUsername is missing.");
     }
-    this.apiKey = process.env.API_KEY;
-    this.apiUser = process.env.API_USERNAME;
+    this.apiKey = config.apiKey;
+    this.apiUser = config.apiUsername;
     this.protocol = "https:";
     this.host = "api.paubox.net";
     this.port = 443;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paubox-node",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A Node.js module for the Paubox Transactional Email API.",
   "main": "index.js",
   "scripts": {

--- a/src/service/emailService.js
+++ b/src/service/emailService.js
@@ -5,15 +5,20 @@ const _getAuthheader = Symbol('getAuthheader');
 const _convertMsgObjtoJSONReqObj = Symbol('convertMsgObjtoJSONReqObj');
 
 class emailService {
-  constructor() {
-    if (!process.env.API_KEY) {
+  constructor(config) {
+    config = Object.assign({
+      apiUsername: process.env.API_USERNAME,
+      apiKey: process.env.API_KEY,
+    }, config);
+
+    if (!config.apiKey) {
       throw new Error("apiKey is missing.");
     }
-    if (!process.env.API_USERNAME) {
+    if (!config.apiUsername) {
       throw new Error("apiUsername is missing.");
     }
-    this.apiKey = process.env.API_KEY;
-    this.apiUser = process.env.API_USERNAME;
+    this.apiKey = config.apiKey;
+    this.apiUser = config.apiUsername;
     this.protocol = "https:";
     this.host = "api.paubox.net";
     this.port = 443;


### PR DESCRIPTION
Allow passing in `apiKey` and `apiUsername` as parameters when creating `emailService`.

This is very useful when the application pulling secrets from an external secret-manager and does not have the credentials set to environment variables.