### PR TITLE
Add support for list-unsubscribe headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ var attachmentContent = Buffer.from('Hello! This is the attachment content!').to
 var options = {
   from: 'sender@domain.com',
   reply_to: 'reply_to@domain.com',
-  listUnsubscribe: '<mailto: unsubscribe@example.com?subject=unsubscribe>, <http://www.example.com/unsubscribe.html>',
-  listUnsubscribePost: '<http://www.example.com/unsubscribe>'
+  list_unsubscribe: '<mailto: unsubscribe@example.com?subject=unsubscribe>, <http://www.example.com/unsubscribe.html>',
+  list_unsubscribe_post: '<http://www.example.com/unsubscribe>'
   reply_to: 'reply_to@domain.com',
   to: ['recipient@example.com'],
   bcc: ['recipient2@example.com'],

--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ var attachmentContent = Buffer.from('Hello! This is the attachment content!').to
 var options = {
   from: 'sender@domain.com',
   reply_to: 'reply_to@domain.com',
+  listUnsubscribe: '<mailto: unsubscribe@example.com?subject=unsubscribe>, <http://www.example.com/unsubscribe.html>',
+  listUnsubscribePost: '<http://www.example.com/unsubscribe>'
+  reply_to: 'reply_to@domain.com',
   to: ['recipient@example.com'],
   bcc: ['recipient2@example.com'],
   cc: ['recipientcc@example.com'],

--- a/src/data/message.js
+++ b/src/data/message.js
@@ -4,6 +4,8 @@ class Message {
   constructor(options) {
     this.from = options.from;
     this.replyTo = options.reply_to;
+    this.listUnsubscribe = options.list_unsubscribe;
+    this.listUnsubscribePost = options.list_unsubcribe_post;
     this.to = options.to;
     this.cc = options.cc;
     this.bcc = options.bcc;

--- a/src/service/emailService.js
+++ b/src/service/emailService.js
@@ -64,6 +64,8 @@ class emailService {
     headers.subject = msg.subject;
     headers.from = msg.from;
     headers["reply-to"] = msg.replyTo;
+    headers["List-Unsubscribe"] = msg.listUnsubscribe;
+    headers["List-Unsubscribe-Post"] = msg.listUnsubscribePost;
 
     content["text/plain"] = msg.plaintext;
 


### PR DESCRIPTION
## Changes
- Add support for `list-unsubscribe` and `list-unsubscribe-post` headers from message object contents.
- Add documentation on the readme.