### PR TITLE
Add List Unsubscribe Header

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,30 @@ var options = {
 var message = pbMail.message(options)
 ```
 
+### Adding the List-Unsubscribe Header
+The List-Unsubscribe header provides the recipient with the option to easily opt-out of receiving any future communications. A more detailed explaination and usage guide for this header can be found at our [docs here.](https://docs.paubox.com/docs/paubox_email_api/messages/#list-unsubscribe)
+
+This header can be used by adding the `list_unsubscribe: '<Email Unsubscribe Address>, <Web Unsubscribe URL'` and `list_unsubscribe_post: 'List-Unsubscribe=One-Click'` key-value pairs to the options object as follows:
+
+```javascript
+"use strict";
+require('dotenv').config();
+const pbMail = require('paubox-node');
+const service = pbMail.emailService();
+
+var options = {
+  from: 'sender@domain.com',
+  to: ['recipient@example.com'],
+  subject: 'Testing!',
+  text_content: 'Hello World!',
+  html_content: '<html><head></head><body><h1>Hello World!</h1></body></html>',
+  list_unsubscribe: '<mailto: unsubscribe@example.com?subject=unsubscribe>, <http://www.example.com/unsubscribe.html>',
+  list_unsubscribe_post: 'List-Unsubscribe=One-Click'
+}
+
+var message = pbMail.message(options)
+
+
 ### Adding Attachments and Additional Headers
 
 

--- a/lib/data/message.js
+++ b/lib/data/message.js
@@ -16,6 +16,7 @@ var Message = function Message(options) {
   this.plaintext = options.text_content;
   this.htmltext = options.html_content;
   this.attachments = options.attachments;
+  this.listUnsubscribe = options.list_unsubscribe;
 };
 
 module.exports = function (options) {

--- a/lib/data/message.js
+++ b/lib/data/message.js
@@ -17,6 +17,7 @@ var Message = function Message(options) {
   this.htmltext = options.html_content;
   this.attachments = options.attachments;
   this.listUnsubscribe = options.list_unsubscribe;
+  this.listUnsubscribePost = options.list_unsubscribe_post;
 };
 
 module.exports = function (options) {

--- a/lib/service/emailService.js
+++ b/lib/service/emailService.js
@@ -80,8 +80,8 @@ function () {
       headers.subject = msg.subject;
       headers.from = msg.from;
       headers["reply-to"] = msg.replyTo;
-      headers["List-Unsubscribe"] = msg.listUnsubscribe
-      headers["List-Unsubscribe-Post"] = msg.listUnsubscribePost
+      headers["List-Unsubscribe"] = msg.listUnsubscribe;
+      headers["List-Unsubscribe-Post"] = msg.listUnsubscribePost;
       content["text/plain"] = msg.plaintext; //base 64 encoding html text
 
       if (msg.htmltext != null && msg.htmltext != "") {

--- a/lib/service/emailService.js
+++ b/lib/service/emailService.js
@@ -81,6 +81,7 @@ function () {
       headers.from = msg.from;
       headers["reply-to"] = msg.replyTo;
       headers["List-Unsubscribe"] = msg.listUnsubscribe
+      headers["List-Unsubscribe-Post"] = msg.listUnsubscribePost
       content["text/plain"] = msg.plaintext; //base 64 encoding html text
 
       if (msg.htmltext != null && msg.htmltext != "") {

--- a/lib/service/emailService.js
+++ b/lib/service/emailService.js
@@ -80,6 +80,7 @@ function () {
       headers.subject = msg.subject;
       headers.from = msg.from;
       headers["reply-to"] = msg.replyTo;
+      headers["List-Unsubscribe"] = msg.listUnsubscribe
       content["text/plain"] = msg.plaintext; //base 64 encoding html text
 
       if (msg.htmltext != null && msg.htmltext != "") {

--- a/src/data/message.js
+++ b/src/data/message.js
@@ -13,6 +13,7 @@ class Message {
     this.plaintext = options.text_content;
     this.htmltext = options.html_content;
     this.attachments = options.attachments;
+    this.listUnsubscribe = options.list_unsubscribe;
   }  
 }
 

--- a/src/data/message.js
+++ b/src/data/message.js
@@ -14,6 +14,7 @@ class Message {
     this.htmltext = options.html_content;
     this.attachments = options.attachments;
     this.listUnsubscribe = options.list_unsubscribe;
+    this.listUnsubscribePost = options.list_unsubscribe_post;
   }  
 }
 

--- a/src/service/emailService.js
+++ b/src/service/emailService.js
@@ -64,8 +64,8 @@ class emailService {
     headers.subject = msg.subject;
     headers.from = msg.from;
     headers["reply-to"] = msg.replyTo;
-    headers["List-Unsubscribe"] = msg.listUnsubscribe
-    headers["List-Unsubscribe-Post"] = msg.listUnsubscribePost
+    headers["List-Unsubscribe"] = msg.listUnsubscribe;
+    headers["List-Unsubscribe-Post"] = msg.listUnsubscribePost;
 
     content["text/plain"] = msg.plaintext;
 

--- a/src/service/emailService.js
+++ b/src/service/emailService.js
@@ -65,6 +65,7 @@ class emailService {
     headers.from = msg.from;
     headers["reply-to"] = msg.replyTo;
     headers["List-Unsubscribe"] = msg.listUnsubscribe
+    headers["List-Unsubscribe-Post"] = msg.listUnsubscribePost
 
     content["text/plain"] = msg.plaintext;
 

--- a/src/service/emailService.js
+++ b/src/service/emailService.js
@@ -64,6 +64,7 @@ class emailService {
     headers.subject = msg.subject;
     headers.from = msg.from;
     headers["reply-to"] = msg.replyTo;
+    headers["List-Unsubscribe"] = msg.listUnsubscribe
 
     content["text/plain"] = msg.plaintext;
 


### PR DESCRIPTION
Implement functionality for users to pass in `list_unsubscribe` and `list_unsubscribe_post` headers to the Message object.