### PR TITLE
Feature: Send templated email

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ The API wrapper allows you to construct and send messages.
   - [Get Email Disposition](#get-email-disposition)
   - [Dynamic Templates](#dynamic-templates)
     - [Create Dynamic Template](#create-dynamic-template)
+    - [Update Dynamic Template](#update-dynamic-template)
+    - [Delete Dynamic Template](#delete-dynamic-template)
+    - [Get Dynamic Template](#get-dynamic-template)
+    - [List Dynamic Templates](#list-dynamic-templates)
+    - [Send an Email using a Dynamic Template](#send-an-email-using-a-dynamic-template)
 - [Supported Node Versions](#supported-node-versions)
 - [Contributing](#contributing)
 - [License](#license)
@@ -321,6 +326,105 @@ app.post('/api/create-dynamic-template', upload.single('templateFile'), async (r
   }
 });
 ```
+
+#### Update Dynamic Template
+
+Please also see the [API Documentation](https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#update-a-dynamic-template).
+
+You can update a dynamic template's content and/or name:
+
+```javascript
+'use strict';
+require('dotenv').config();
+const pbMail = require('paubox-node');
+const service = pbMail.emailService();
+
+const templateId = 123; // You would get this from the listDynamicTemplates method (see below)
+const templateName = 'New Name';
+const templateContent = '<html><body><h1>Hello {{firstName}}!</h1></body></html>'; // New content
+
+service.updateDynamicTemplate(templateId, templateName, templateContent).then(function (response) {
+  console.log('Update Dynamic Template method Response: ' + JSON.stringify(response));
+});
+
+// Or just update the content
+service.updateDynamicTemplate(templateId, null, templateContent).then(function (response) {
+  console.log('Update Dynamic Template method Response: ' + JSON.stringify(response));
+});
+```
+
+In a simple express app, this could look something like this:
+
+```javascript
+require('dotenv').config();
+const pbMail = require('paubox-node');
+const service = pbMail.emailService();
+
+app.patch('/api/update-dynamic-template/:templateId', upload.single('templateFile'), async (req, res) => {
+  try {
+    const { templateId } = req.params;
+    const { templateName } = req.body;
+    const templateFile = req.file;
+
+    const content = templateFile.buffer;
+    const response = await service.updateDynamicTemplate(templateId, templateName, content);
+    res.json(response);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+```
+
+#### Delete Dynamic Template
+
+Please also see the [API Documentation](https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#delete-a-dynamic-template).
+
+```javascript
+'use strict';
+require('dotenv').config();
+const pbMail = require('paubox-node');
+const service = pbMail.emailService();
+
+const templateId = 123; // You would get this from the listDynamicTemplates method (see below)
+
+service.deleteDynamicTemplate(templateId).then(function (response) {
+  console.log('Delete Dynamic Template method Response: ' + JSON.stringify(response));
+});
+```
+
+#### Get Dynamic Template
+
+Please also see the [API Documentation](https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#view-one-of-your-orgs-dynamic-templates).
+
+```javascript
+'use strict';
+require('dotenv').config();
+const pbMail = require('paubox-node');
+const service = pbMail.emailService();
+
+const templateId = 123; // You would get this from the listDynamicTemplates method (see below)
+
+service.getDynamicTemplate(templateId).then(function (response) {
+  console.log('Get Dynamic Template method Response: ' + JSON.stringify(response));
+});
+```
+
+#### List Dynamic Templates
+
+Please also see the [API Documentation](https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#view-all-your-orgs-dynamic-templates).
+
+```javascript
+'use strict';
+require('dotenv').config();
+const pbMail = require('paubox-node');
+const service = pbMail.emailService();
+
+service.listDynamicTemplates().then(function (response) {
+  console.log('List Dynamic Templates method Response: ' + JSON.stringify(response));
+});
+```
+
+#### Send an Email using a Dynamic Template
 
 ## Supported Node Versions
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The API wrapper allows you to construct and send messages.
     - [Delete Dynamic Template](#delete-dynamic-template)
     - [Get Dynamic Template](#get-dynamic-template)
     - [List Dynamic Templates](#list-dynamic-templates)
-    - [Send an Email using a Dynamic Template](#send-an-email-using-a-dynamic-template)
+    - [Send a Dynamically Templated Message](#send-a-dynamically-templated-message)
 - [Supported Node Versions](#supported-node-versions)
 - [Contributing](#contributing)
 - [License](#license)
@@ -86,6 +86,9 @@ emailService.
 ### Send Message
 
 Please also see the [API Documentation](https://docs.paubox.com/docs/paubox_email_api/messages#send-message).
+
+Please also see [Sending a Dynamically Templated Message](#send-a-dynamically-templated-message) for sending a message
+using a dynamic template.
 
 ```javascript
 'use strict';
@@ -424,7 +427,54 @@ service.listDynamicTemplates().then(function (response) {
 });
 ```
 
-#### Send an Email using a Dynamic Template
+#### Send a Dynamically Templated Message
+
+Please also see the [API Documentation](https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#send-a-dynamically-templated-message).
+
+This is similar to the [sendMessage](#send-message) method, but you pass in `template_name` and `template_values`
+instead of `text_content` and `html_content` when constructing the `Message` object.
+
+For example, assume you have a dynamic template named `welcome_email` with the following content:
+
+```html
+<html>
+  <body>
+    <h1>Welcome {{firstName}} {{lastName}}!</h1>
+  </body>
+</html>
+```
+
+You can send a message using this template by doing the following:
+
+```javascript
+'use strict';
+require('dotenv').config();
+const pbMail = require('paubox-node');
+const service = pbMail.emailService();
+
+const templateName = 'welcome_email';
+const templateValues = {
+  firstName: 'John',
+  lastName: 'Doe',
+};
+
+var message = pbMail.message({
+  from: 'sender@domain.com',
+  to: ['recipient@example.com'],
+  subject: 'Welcome!',
+  template_name: templateName,
+  template_values: templateValues,
+});
+
+service
+  .sendTemplatedMessage(message)
+  .then((response) => {
+    console.log('Send Templated Message method Response: ' + JSON.stringify(response));
+  })
+  .catch((error) => {
+    console.log('Error in Send Templated Message method: ' + JSON.stringify(error));
+  });
+```
 
 ## Supported Node Versions
 

--- a/README.md
+++ b/README.md
@@ -363,19 +363,23 @@ require('dotenv').config();
 const pbMail = require('paubox-node');
 const service = pbMail.emailService();
 
-app.patch('/api/update-dynamic-template/:templateId', upload.single('templateFile'), async (req, res) => {
-  try {
-    const { templateId } = req.params;
-    const { templateName } = req.body;
-    const templateFile = req.file;
+app.patch(
+  '/api/update-dynamic-template/:templateId',
+  upload.single('templateFile'),
+  async (req, res) => {
+    try {
+      const { templateId } = req.params;
+      const { templateName } = req.body;
+      const templateFile = req.file;
 
-    const content = templateFile.buffer;
-    const response = await service.updateDynamicTemplate(templateId, templateName, content);
-    res.json(response);
-  } catch (error) {
-    res.status(500).json({ error: error.message });
-  }
-});
+      const content = templateFile.buffer;
+      const response = await service.updateDynamicTemplate(templateId, templateName, content);
+      res.json(response);
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+    }
+  },
+);
 ```
 
 #### Delete Dynamic Template
@@ -467,12 +471,12 @@ var message = pbMail.message({
 });
 
 service
-  .sendTemplatedMessage(message)
+  .sendMessage(message)
   .then((response) => {
-    console.log('Send Templated Message method Response: ' + JSON.stringify(response));
+    console.log('Send Message method Response: ' + JSON.stringify(response));
   })
   .catch((error) => {
-    console.log('Error in Send Templated Message method: ' + JSON.stringify(error));
+    console.log('Error in Send Message method: ' + JSON.stringify(error));
   });
 ```
 

--- a/README.md
+++ b/README.md
@@ -471,12 +471,12 @@ var message = pbMail.message({
 });
 
 service
-  .sendMessage(message)
+  .sendTemplatedMessage(message)
   .then((response) => {
-    console.log('Send Message method Response: ' + JSON.stringify(response));
+    console.log('Send Templated Message method Response: ' + JSON.stringify(response));
   })
   .catch((error) => {
-    console.log('Error in Send Message method: ' + JSON.stringify(error));
+    console.log('Error in Send Templated Message method: ' + JSON.stringify(error));
   });
 ```
 

--- a/README.md
+++ b/README.md
@@ -435,9 +435,6 @@ service.listDynamicTemplates().then(function (response) {
 
 Please also see the [API Documentation](https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#send-a-dynamically-templated-message).
 
-This is similar to the [sendMessage](#send-message) method, but you pass in `template_name` and `template_values`
-instead of `text_content` and `html_content` when constructing the `Message` object.
-
 For example, assume you have a dynamic template named `welcome_email` with the following content:
 
 ```html
@@ -462,7 +459,7 @@ const templateValues = {
   lastName: 'Doe',
 };
 
-var message = pbMail.message({
+var templatedMessage = pbMail.templatedMessage({
   from: 'sender@domain.com',
   to: ['recipient@example.com'],
   subject: 'Welcome!',
@@ -471,7 +468,7 @@ var message = pbMail.message({
 });
 
 service
-  .sendTemplatedMessage(message)
+  .sendTemplatedMessage(templatedMessage)
   .then((response) => {
     console.log('Send Templated Message method Response: ' + JSON.stringify(response));
   })

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const emailService = require('./lib/service/emailService.js');
 const message = require('./lib/data/message.js');
+const templatedMessage = require('./lib/data/templatedMessage.js');
 
 module.exports.emailService = function (config) {
   return new emailService(config);
@@ -7,4 +8,8 @@ module.exports.emailService = function (config) {
 
 module.exports.message = function (options) {
   return new message(options);
+};
+
+module.exports.templatedMessage = function (options) {
+  return new templatedMessage(options);
 };

--- a/lib/data/message.js
+++ b/lib/data/message.js
@@ -10,15 +10,47 @@ class Message {
     this.subject = options.subject;
     this.allowNonTLS = options.allowNonTLS || false;
     this.forceSecureNotification = options.forceSecureNotification;
-    this.plaintext = options.text_content;
-    this.htmltext = options.html_content;
     this.attachments = options.attachments;
     this.listUnsubscribe = options.list_unsubscribe;
-    this.listUnsubscribePost = options.list_unsubscribe_post;
+    this.listUnsubscribePost = options.list_unsubscribe_post; // Email content for non-templated messages (https://docs.paubox.com/docs/paubox_email_api/messages#send-message)
+
+    this.plaintext = options.text_content;
+    this.htmltext = options.html_content; // Email content for templated messages (https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#send-a-dynamically-templated-message)
+
+    this.templateName = options.template_name;
+    this.templateValues = options.template_values; // Determine if this is a templated message
+
+    this.isTemplated = Boolean(this.templateName && this.templateValues);
+    this.validate();
+  } // Performs some validation on the message object, throwing an error if the message is invalid.
+  //
+  // Messages must:
+  // - have either templated or non-templated content fields, but not both.
+  // - have template values if a template name is provided.
+  // - have valid JSON for template values.
+  //
+
+  validate() {
+    // TODO: ADD OTHER VALIDATIONS HERE
+    const hasContent = this.plaintext || this.htmltext;
+
+    if (this.isTemplated && hasContent) {
+      throw new Error('Message cannot have both template and content fields');
+    }
+
+    if (!this.isTemplated && !hasContent) {
+      throw new Error('Message must have either template or content fields');
+    }
+
+    if (this.isTemplated) {
+      if (typeof this.templateValues !== 'object') {
+        throw new Error('Template values must be a valid JSON object');
+      }
+    }
   } // Convert Message object to JSON object in Paubox API format
 
   toJSON() {
-    return {
+    let jsonContent = {
       recipients: this.to,
       cc: this.cc,
       bcc: this.bcc,
@@ -31,12 +63,25 @@ class Message {
       },
       allowNonTLS: this.parseBool(this.allowNonTLS),
       forceSecureNotification: this.parseBool(this.forceSecureNotification),
-      content: {
-        'text/plain': this.plaintext,
-        'text/html': this.safeBase64Encode(this.htmltext),
-      },
-      attachments: this.attachments,
     };
+
+    if (!this.isTemplated) {
+      jsonContent = {
+        ...jsonContent,
+        content: {
+          'text/plain': this.plaintext,
+          'text/html': this.safeBase64Encode(this.htmltext),
+        },
+      };
+    }
+
+    if (this.attachments) {
+      jsonContent = { ...jsonContent, attachments: this.attachments };
+    } else {
+      jsonContent = { ...jsonContent, attachments: null };
+    }
+
+    return jsonContent;
   } // Safely base64 encodes a string, handling null and empty strings
 
   safeBase64Encode(text) {

--- a/lib/data/message.js
+++ b/lib/data/message.js
@@ -1,24 +1,53 @@
 'use strict';
+/**
+ * Creates a new Message object for sending email messages through Paubox
+ *
+ * @param {Object} options - Required. The message options
+ *
+ * @param {string} options.from - Required. The sender's email address. Should be from a domain that you have authorized.
+ * @param {string[]} options.to - Required. Array of recipient email addresses
+ *
+ * For non-templated messages, one of these is required:
+ * @param {string} [options.text_content] - Plain text content of the email. Defaults to null.
+ * @param {string} [options.html_content] - HTML content of the email. Defaults to null.
+ *
+ * For templated messages, both of these are required:
+ * @param {string} [options.template_name] - Name of the template to use. Defaults to null.
+ * @param {Object} [options.template_values] - JSON object containing template variables. Defaults to null.
+ *
+ * Optional fields:
+ * @param {string} [options.subject] - Optional. The email subject. Defaults to null.
+ * @param {string} [options.reply_to] - Reply-to email address. Defaults to null.
+ * @param {string[]} [options.cc] - Array of CC recipient email addresses. Defaults to null.
+ * @param {string[]} [options.bcc] - Array of BCC recipient email addresses. Defaults to null.
+ * @param {boolean} [options.allowNonTLS=false] - Whether to allow non-TLS message delivery. Defaults to false.
+ * @param {boolean} [options.forceSecureNotification=false] - Whether to force secure notifications. Defaults to false.
+ * @param {Array<Object>} [options.attachments] - Array of attachment objects. Defaults to null.
+ * @param {string} [options.list_unsubscribe] - List-Unsubscribe header value. Defaults to null.
+ * @param {string} [options.list_unsubscribe_post] - List-Unsubscribe-Post header value. Defaults to null.
+ *
+ * @throws {Error} If validation fails
+ */
 
 class Message {
   constructor(options) {
     this.from = options.from;
-    this.replyTo = options.reply_to;
     this.to = options.to;
-    this.cc = options.cc;
-    this.bcc = options.bcc;
-    this.subject = options.subject;
+    this.replyTo = options.reply_to || null;
+    this.cc = options.cc || null;
+    this.bcc = options.bcc || null;
+    this.subject = options.subject || null;
     this.allowNonTLS = options.allowNonTLS || false;
-    this.forceSecureNotification = options.forceSecureNotification;
-    this.attachments = options.attachments;
-    this.listUnsubscribe = options.list_unsubscribe;
-    this.listUnsubscribePost = options.list_unsubscribe_post; // Email content for non-templated messages (https://docs.paubox.com/docs/paubox_email_api/messages#send-message)
+    this.forceSecureNotification = options.forceSecureNotification || false;
+    this.attachments = options.attachments || null;
+    this.listUnsubscribe = options.list_unsubscribe || null;
+    this.listUnsubscribePost = options.list_unsubscribe_post || null; // Email content for non-templated messages (https://docs.paubox.com/docs/paubox_email_api/messages#send-message)
 
-    this.plaintext = options.text_content;
-    this.htmltext = options.html_content; // Email content for templated messages (https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#send-a-dynamically-templated-message)
+    this.plaintext = options.text_content || null;
+    this.htmltext = options.html_content || null; // Email content for templated messages (https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#send-a-dynamically-templated-message)
 
-    this.templateName = options.template_name;
-    this.templateValues = options.template_values; // Determine if this is a templated message
+    this.templateName = options.template_name || null;
+    this.templateValues = options.template_values || null; // Determine if this is a templated message
 
     this.isTemplated = Boolean(this.templateName && this.templateValues);
     this.validate();
@@ -31,7 +60,14 @@ class Message {
   //
 
   validate() {
-    // TODO: ADD OTHER VALIDATIONS HERE
+    if (!this.from) {
+      throw new Error('From address is required');
+    }
+
+    if (!this.to) {
+      throw new Error('To address(es) are required');
+    }
+
     const hasContent = this.plaintext || this.htmltext;
 
     if (this.isTemplated && hasContent) {

--- a/lib/data/templatedMessage.js
+++ b/lib/data/templatedMessage.js
@@ -1,16 +1,14 @@
 'use strict';
 /**
- * Creates a new Message object for sending email messages through Paubox using the sendMessage and sendTemplatedMessage
- * methods.
- *
- * NOTE: For templated messages, use the TemplatedMessage object and the sendTemplatedMessage method.
+ * Creates a new TemplatedMessage object for sending email messages through Paubox using the sendTemplatedMessage
+ * method.
  *
  * @param {Object} options - Required. The message options
  *
  * @param {string} options.from - Required. The sender's email address. Should be from a domain that you have authorized.
  * @param {string[]} options.to - Required. Array of recipient email addresses
- * @param {string} options.text_content - Plain text content of the email.
- * @param {string} options.html_content - HTML content of the email.
+ * @param {string} options.template_name - Required. The name of the template to use.
+ * @param {Object} options.template_values - Required. The values to use for the template. Must be a valid JSON object.
  *
  * Optional fields:
  * @param {string} [options.subject] - Optional. The email subject. Defaults to null.
@@ -26,7 +24,7 @@
  * @throws {Error} If validation fails
  */
 
-class Message {
+class TemplatedMessage {
   constructor(options) {
     this.from = options.from;
     this.to = options.to;
@@ -39,15 +37,16 @@ class Message {
     this.attachments = options.attachments || null;
     this.listUnsubscribe = options.list_unsubscribe || null;
     this.listUnsubscribePost = options.list_unsubscribe_post || null;
-    this.plaintext = options.text_content;
-    this.htmltext = options.html_content;
+    this.templateName = options.template_name;
+    this.templateValues = options.template_values;
     this.validate();
   } // Performs some validation on the message object, throwing an error if the message is invalid.
   //
   // Messages must:
   //
   //   - have a from and to address
-  //   - have either or both text and html content
+  //   - have both a template name and template values
+  //   - have valid JSON for template values
   //
 
   validate() {
@@ -59,10 +58,12 @@ class Message {
       throw new Error('One or more to addresses are required');
     }
 
-    const hasContent = this.plaintext || this.htmltext;
+    if (!this.templateName) {
+      throw new Error('Template name is required');
+    }
 
-    if (!hasContent) {
-      throw new Error('Message must have either plaintext or html text');
+    if (typeof this.templateValues !== 'object') {
+      throw new Error('Template values must be a valid JSON object');
     }
   } // Convert Message object to JSON object in Paubox API format
 
@@ -77,10 +78,6 @@ class Message {
         'reply-to': this.replyTo,
         'List-Unsubscribe': this.listUnsubscribe,
         'List-Unsubscribe-Post': this.listUnsubscribePost,
-      },
-      content: {
-        'text/plain': this.plaintext,
-        'text/html': this.safeBase64Encode(this.htmltext),
       },
       attachments: this.attachments,
       allowNonTLS: this.parseBool(this.allowNonTLS),
@@ -110,5 +107,5 @@ class Message {
 }
 
 module.exports = function (options) {
-  return new Message(options);
+  return new TemplatedMessage(options);
 };

--- a/lib/service/emailService.js
+++ b/lib/service/emailService.js
@@ -6,6 +6,10 @@ const Stream = require('stream');
 
 const FormData = require('form-data');
 
+const Message = require('../data/message.js');
+
+const TemplatedMessage = require('../data/templatedMessage.js');
+
 class emailService {
   constructor(config) {
     config = Object.assign(
@@ -82,16 +86,14 @@ class emailService {
   //
   // msg is a Message object
   //
-  // This method is for sending non-templated messages. For templated messages, use sendTemplatedMessage() instead.
+  // This method is for sending (non-templated) Messages. For templated messages, use sendTemplatedMessage() instead.
   //
   // returns a promise that resolves to the response from the API
   //
 
   async sendMessage(msg) {
-    if (msg.isTemplated) {
-      throw new Error(
-        'Message cannot be a templated message. Please use sendTemplatedMessage() instead.',
-      );
+    if (!msg || msg.constructor.name !== 'Message') {
+      throw new Error('Message must be a Message object');
     }
 
     var requestBody = {
@@ -110,16 +112,16 @@ class emailService {
   //
   // https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#send-a-dynamically-templated-message
   //
-  // msg is a Message object
+  // msg is a TemplatedMessage object
   //
-  // This method is for sending templated messages. For non-templated messages, use sendMessage() instead.
+  // This method is for sending TemplatedMessages. For non-templated messages, use sendMessage() instead.
   //
   // returns a promise that resolves to the response from the API
   //
 
   async sendTemplatedMessage(msg) {
-    if (!msg.isTemplated) {
-      throw new Error('Message must be a templated message. Please use sendMessage() instead.');
+    if (!msg || msg.constructor.name !== 'TemplatedMessage') {
+      throw new Error('Message must be a TemplatedMessage object');
     }
 
     var requestBody = {

--- a/lib/service/emailService.js
+++ b/lib/service/emailService.js
@@ -82,16 +82,54 @@ class emailService {
   //
   // msg is a Message object
   //
+  // This method is for sending non-templated messages. For templated messages, use sendTemplatedMessage() instead.
+  //
   // returns a promise that resolves to the response from the API
   //
 
   async sendMessage(msg) {
+    if (msg.isTemplated) {
+      throw new Error(
+        'Message cannot be a templated message. Please use sendTemplatedMessage() instead.',
+      );
+    }
+
     var requestBody = JSON.stringify({
       data: {
         message: msg.toJSON(),
       },
     });
     const response = await this.apiHelper.post(this.baseURL, '/messages', requestBody);
+
+    if (response.data == null && response.sourceTrackingId == null && response.errors == null) {
+      throw response;
+    }
+
+    return response;
+  } // Send a templated email message
+  //
+  // https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#send-a-dynamically-templated-message
+  //
+  // msg is a Message object
+  //
+  // This method is for sending templated messages. For non-templated messages, use sendMessage() instead.
+  //
+  // returns a promise that resolves to the response from the API
+  //
+
+  async sendTemplatedMessage(msg) {
+    if (!msg.isTemplated) {
+      throw new Error('Message must be a templated message. Please use sendMessage() instead.');
+    }
+
+    var requestBody = JSON.stringify({
+      data: {
+        template_name: msg.templateName,
+        template_values: JSON.stringify(msg.templateValues),
+        message: msg.toJSON(),
+      },
+    });
+    const response = await this.apiHelper.post(this.baseURL, '/templated_messages', requestBody);
 
     if (response.data == null && response.sourceTrackingId == null && response.errors == null) {
       throw response;

--- a/src/data/message.js
+++ b/src/data/message.js
@@ -7,16 +7,16 @@
  *
  * @param {string} options.from - Required. The sender's email address. Should be from a domain that you have authorized.
  * @param {string[]} options.to - Required. Array of recipient email addresses
-*
-* For non-templated messages, one of these is required:
-* @param {string} [options.text_content] - Plain text content of the email. Defaults to null.
-* @param {string} [options.html_content] - HTML content of the email. Defaults to null.
-*
-* For templated messages, both of these are required:
-* @param {string} [options.template_name] - Name of the template to use. Defaults to null.
-* @param {Object} [options.template_values] - JSON object containing template variables. Defaults to null.
-*
-* Optional fields:
+ *
+ * For non-templated messages, one of these is required:
+ * @param {string} [options.text_content] - Plain text content of the email. Defaults to null.
+ * @param {string} [options.html_content] - HTML content of the email. Defaults to null.
+ *
+ * For templated messages, both of these are required:
+ * @param {string} [options.template_name] - Name of the template to use. Defaults to null.
+ * @param {Object} [options.template_values] - JSON object containing template variables. Defaults to null.
+ *
+ * Optional fields:
  * @param {string} [options.subject] - Optional. The email subject. Defaults to null.
  * @param {string} [options.reply_to] - Reply-to email address. Defaults to null.
  * @param {string[]} [options.cc] - Array of CC recipient email addresses. Defaults to null.

--- a/src/data/message.js
+++ b/src/data/message.js
@@ -45,11 +45,15 @@ class Message {
     }
 
     if (hasTemplate) {
+      this.isTemplated = true;
       if (typeof this.templateValues !== 'object') {
         throw new Error('Template values must be a valid JSON object');
       }
+    } else {
+      this.isTemplated = false;
     }
   }
+
 
   // Convert Message object to JSON object in Paubox API format
   toJSON() {

--- a/src/data/message.js
+++ b/src/data/message.js
@@ -36,6 +36,8 @@ class Message {
   // - have valid JSON for template values.
   //
   validate() {
+    // TODO: ADD OTHER VALIDATIONS HERE
+
     const hasContent = this.plaintext || this.htmltext;
 
     if (this.isTemplated && hasContent) {
@@ -52,7 +54,6 @@ class Message {
       }
     }
   }
-
 
   // Convert Message object to JSON object in Paubox API format
   toJSON() {
@@ -71,9 +72,7 @@ class Message {
       forceSecureNotification: this.parseBool(this.forceSecureNotification),
     };
 
-    if (this.templateName && this.templateValues) {
-      jsonContent = { ...jsonContent, template_name: this.templateName, template_values: this.templateValues };
-    } else {
+    if (!this.isTemplated) {
       jsonContent = {
         ...jsonContent,
         content: {

--- a/src/data/message.js
+++ b/src/data/message.js
@@ -1,26 +1,55 @@
 'use strict';
 
+/**
+ * Creates a new Message object for sending email messages through Paubox
+ *
+ * @param {Object} options - Required. The message options
+ *
+ * @param {string} options.from - Required. The sender's email address. Should be from a domain that you have authorized.
+ * @param {string[]} options.to - Required. Array of recipient email addresses
+*
+* For non-templated messages, one of these is required:
+* @param {string} [options.text_content] - Plain text content of the email. Defaults to null.
+* @param {string} [options.html_content] - HTML content of the email. Defaults to null.
+*
+* For templated messages, both of these are required:
+* @param {string} [options.template_name] - Name of the template to use. Defaults to null.
+* @param {Object} [options.template_values] - JSON object containing template variables. Defaults to null.
+*
+* Optional fields:
+ * @param {string} [options.subject] - Optional. The email subject. Defaults to null.
+ * @param {string} [options.reply_to] - Reply-to email address. Defaults to null.
+ * @param {string[]} [options.cc] - Array of CC recipient email addresses. Defaults to null.
+ * @param {string[]} [options.bcc] - Array of BCC recipient email addresses. Defaults to null.
+ * @param {boolean} [options.allowNonTLS=false] - Whether to allow non-TLS message delivery. Defaults to false.
+ * @param {boolean} [options.forceSecureNotification=false] - Whether to force secure notifications. Defaults to false.
+ * @param {Array<Object>} [options.attachments] - Array of attachment objects. Defaults to null.
+ * @param {string} [options.list_unsubscribe] - List-Unsubscribe header value. Defaults to null.
+ * @param {string} [options.list_unsubscribe_post] - List-Unsubscribe-Post header value. Defaults to null.
+ *
+ * @throws {Error} If validation fails
+ */
 class Message {
   constructor(options) {
     this.from = options.from;
-    this.replyTo = options.reply_to;
     this.to = options.to;
-    this.cc = options.cc;
-    this.bcc = options.bcc;
-    this.subject = options.subject;
+    this.replyTo = options.reply_to || null;
+    this.cc = options.cc || null;
+    this.bcc = options.bcc || null;
+    this.subject = options.subject || null;
     this.allowNonTLS = options.allowNonTLS || false;
-    this.forceSecureNotification = options.forceSecureNotification;
-    this.attachments = options.attachments;
-    this.listUnsubscribe = options.list_unsubscribe;
-    this.listUnsubscribePost = options.list_unsubscribe_post;
+    this.forceSecureNotification = options.forceSecureNotification || false;
+    this.attachments = options.attachments || null;
+    this.listUnsubscribe = options.list_unsubscribe || null;
+    this.listUnsubscribePost = options.list_unsubscribe_post || null;
 
     // Email content for non-templated messages (https://docs.paubox.com/docs/paubox_email_api/messages#send-message)
-    this.plaintext = options.text_content;
-    this.htmltext = options.html_content;
+    this.plaintext = options.text_content || null;
+    this.htmltext = options.html_content || null;
 
     // Email content for templated messages (https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#send-a-dynamically-templated-message)
-    this.templateName = options.template_name;
-    this.templateValues = options.template_values;
+    this.templateName = options.template_name || null;
+    this.templateValues = options.template_values || null;
 
     // Determine if this is a templated message
     this.isTemplated = Boolean(this.templateName && this.templateValues);
@@ -36,7 +65,13 @@ class Message {
   // - have valid JSON for template values.
   //
   validate() {
-    // TODO: ADD OTHER VALIDATIONS HERE
+    if (!this.from) {
+      throw new Error('From address is required');
+    }
+
+    if (!this.to) {
+      throw new Error('To address(es) are required');
+    }
 
     const hasContent = this.plaintext || this.htmltext;
 

--- a/src/service/emailService.js
+++ b/src/service/emailService.js
@@ -3,6 +3,8 @@
 const apiHelper = require('./apiHelper.js');
 const Stream = require('stream');
 const FormData = require('form-data');
+const Message = require('../data/message.js');
+const TemplatedMessage = require('../data/templatedMessage.js');
 
 class emailService {
   constructor(config) {
@@ -68,15 +70,13 @@ class emailService {
   //
   // msg is a Message object
   //
-  // This method is for sending non-templated messages. For templated messages, use sendTemplatedMessage() instead.
+  // This method is for sending (non-templated) Messages. For templated messages, use sendTemplatedMessage() instead.
   //
   // returns a promise that resolves to the response from the API
   //
   async sendMessage(msg) {
-    if (msg.isTemplated) {
-      throw new Error(
-        'Message cannot be a templated message. Please use sendTemplatedMessage() instead.',
-      );
+    if (!msg || msg.constructor.name !== 'Message') {
+      throw new Error('Message must be a Message object');
     }
 
     var requestBody = {
@@ -98,15 +98,15 @@ class emailService {
   //
   // https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#send-a-dynamically-templated-message
   //
-  // msg is a Message object
+  // msg is a TemplatedMessage object
   //
-  // This method is for sending templated messages. For non-templated messages, use sendMessage() instead.
+  // This method is for sending TemplatedMessages. For non-templated messages, use sendMessage() instead.
   //
   // returns a promise that resolves to the response from the API
   //
   async sendTemplatedMessage(msg) {
-    if (!msg.isTemplated) {
-      throw new Error('Message must be a templated message. Please use sendMessage() instead.');
+    if (!msg || msg.constructor.name !== 'TemplatedMessage') {
+      throw new Error('Message must be a TemplatedMessage object');
     }
 
     var requestBody = {

--- a/src/service/emailService.js
+++ b/src/service/emailService.js
@@ -68,9 +68,17 @@ class emailService {
   //
   // msg is a Message object
   //
+  // This method is for sending non-templated messages. For templated messages, use sendTemplatedMessage() instead.
+  //
   // returns a promise that resolves to the response from the API
   //
   async sendMessage(msg) {
+    if (msg.isTemplated) {
+      throw new Error(
+        'Message cannot be a templated message. Please use sendTemplatedMessage() instead.',
+      );
+    }
+
     var requestBody = JSON.stringify({
       data: {
         message: msg.toJSON(),
@@ -78,6 +86,38 @@ class emailService {
     });
 
     const response = await this.apiHelper.post(this.baseURL, '/messages', requestBody);
+
+    if (response.data == null && response.sourceTrackingId == null && response.errors == null) {
+      throw response;
+    }
+
+    return response;
+  }
+
+  // Send a templated email message
+  //
+  // https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#send-a-dynamically-templated-message
+  //
+  // msg is a Message object
+  //
+  // This method is for sending templated messages. For non-templated messages, use sendMessage() instead.
+  //
+  // returns a promise that resolves to the response from the API
+  //
+  async sendTemplatedMessage(msg) {
+    if (!msg.isTemplated) {
+      throw new Error('Message must be a templated message. Please use sendMessage() instead.');
+    }
+
+    var requestBody = JSON.stringify({
+      data: {
+        template_name: msg.templateName,
+        template_values: JSON.stringify(msg.templateValues),
+        message: msg.toJSON(),
+      },
+    });
+
+    const response = await this.apiHelper.post(this.baseURL, '/templated_messages', requestBody);
 
     if (response.data == null && response.sourceTrackingId == null && response.errors == null) {
       throw response;

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -101,7 +101,9 @@ describe('Message.validate', function () {
       template_values: { name: 'John' },
     };
 
-    expect(() => Message(invalidOptions)).to.throw('Message cannot have both template and content fields');
+    expect(() => Message(invalidOptions)).to.throw(
+      'Message cannot have both template and content fields',
+    );
   });
 
   it('throws an error if neither templated nor non-templated content fields are provided', function () {
@@ -114,7 +116,9 @@ describe('Message.validate', function () {
       subject: 'Invalid Message',
     };
 
-    expect(() => Message(invalidOptions)).to.throw('Message must have either template or content fields');
+    expect(() => Message(invalidOptions)).to.throw(
+      'Message must have either template or content fields',
+    );
   });
 
   it('throws an error if template values are not a valid JSON object', function () {

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -158,8 +158,8 @@ describe('Message.validate', function () {
       firstName: 'John',
       lastName: 'Doe',
     });
-    expect(message.plaintext).to.be.undefined;
-    expect(message.htmltext).to.be.undefined;
+    expect(message.plaintext).to.be.null;
+    expect(message.htmltext).to.be.null;
 
     expect(message.isTemplated).to.be.true;
   });
@@ -178,11 +178,56 @@ describe('Message.validate', function () {
 
     const message = Message(validNonTemplatedOptions);
 
-    expect(message.templateName).to.be.undefined;
-    expect(message.templateValues).to.be.undefined;
+    expect(message.templateName).to.be.null;
+    expect(message.templateValues).to.be.null;
     expect(message.plaintext).to.equal('Hello John Doe!');
     expect(message.htmltext).to.equal('<html><body><h1>Hello John Doe!</h1></body></html>');
 
     expect(message.isTemplated).to.be.false;
+  });
+
+  it('throws an error if the from address is not specified', function () {
+    const invalidOptions = {
+      reply_to: 'sender@authorized_domain.com',
+      to: ['recipient@host.com'],
+      subject: 'Invalid Message',
+      text_content: 'Invalid message',
+      html_content: '<html><body><h1>Invalid message</h1></body></html>',
+    };
+
+    expect(() => Message(invalidOptions)).to.throw('From address is required');
+  });
+
+  it('throws an error if the to addresses are not specified', function () {
+    const invalidOptions = {
+      from: 'sender@authorized_domain.com',
+      reply_to: 'sender@authorized_domain.com',
+      subject: 'Invalid Message',
+      text_content: 'Invalid message',
+      html_content: '<html><body><h1>Invalid message</h1></body></html>',
+    };
+
+    expect(() => Message(invalidOptions)).to.throw('To address(es) are required');
+  });
+
+  it('has sane defaults for optional fields', function () {
+    const validOptions = {
+      from: 'sender@authorized_domain.com',
+      to: ['recipient@host.com'],
+      text_content: 'Valid message',
+      html_content: '<html><body><h1>Valid message</h1></body></html>',
+    };
+
+    const message = Message(validOptions);
+
+    expect(message.replyTo).to.be.null;
+    expect(message.subject).to.be.null;
+    expect(message.cc).to.be.null;
+    expect(message.bcc).to.be.null;
+    expect(message.allowNonTLS).to.be.false;
+    expect(message.forceSecureNotification).to.be.false;
+    expect(message.attachments).to.be.null;
+    expect(message.listUnsubscribe).to.be.null;
+    expect(message.listUnsubscribePost).to.be.null;
   });
 });

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -1,6 +1,6 @@
 const chai = require('chai');
 const { expect } = chai;
-const Message = require('../src/data/message.js');
+const Message = require('../src/data/message');
 
 const message = Message({
   from: 'sender@authorized_domain.com',
@@ -87,84 +87,7 @@ describe('Message.toJSON', function () {
 });
 
 describe('Message.validate', function () {
-  it('throws an error if both templated and non-templated content fields are provided', function () {
-    const invalidOptions = {
-      from: 'sender@authorized_domain.com',
-      reply_to: 'sender@authorized_domain.com',
-      to: ['recipient@host.com'],
-      cc: null,
-      bcc: null,
-      subject: 'Invalid Message',
-      text_content: 'Invalid message',
-      html_content: '<html><body><h1>Invalid message</h1></body></html>',
-      template_name: 'test_template',
-      template_values: { name: 'John' },
-    };
-
-    expect(() => Message(invalidOptions)).to.throw(
-      'Message cannot have both template and content fields',
-    );
-  });
-
-  it('throws an error if neither templated nor non-templated content fields are provided', function () {
-    const invalidOptions = {
-      from: 'sender@authorized_domain.com',
-      reply_to: 'sender@authorized_domain.com',
-      to: ['recipient@host.com'],
-      cc: null,
-      bcc: null,
-      subject: 'Invalid Message',
-    };
-
-    expect(() => Message(invalidOptions)).to.throw(
-      'Message must have either template or content fields',
-    );
-  });
-
-  it('throws an error if template values are not a valid JSON object', function () {
-    const invalidOptions = {
-      from: 'sender@authorized_domain.com',
-      reply_to: 'sender@authorized_domain.com',
-      to: ['recipient@host.com'],
-      cc: null,
-      bcc: null,
-      subject: 'Invalid Message',
-      template_name: 'test_template',
-      template_values: 'this_is_not_a_valid_json_object',
-    };
-
-    expect(() => Message(invalidOptions)).to.throw('Template values must be a valid JSON object');
-  });
-
-  it('can construct a valid templated message with valid template values', function () {
-    const validTemplatedOptions = {
-      from: 'sender@authorized_domain.com',
-      reply_to: 'sender@authorized_domain.com',
-      to: ['recipient@host.com'],
-      cc: null,
-      bcc: null,
-      subject: 'Welcome!',
-      template_name: 'welcome_email',
-      template_values: {
-        firstName: 'John',
-        lastName: 'Doe',
-      },
-    };
-
-    const message = Message(validTemplatedOptions);
-
-    expect(message.templateName).to.equal('welcome_email');
-    expect(message.templateValues).to.deep.equal({
-      firstName: 'John',
-      lastName: 'Doe',
-    });
-    expect(message.plaintext).to.be.null;
-    expect(message.htmltext).to.be.null;
-
-    expect(message.isTemplated).to.be.true;
-  });
-
-  it('can construct a valid non-templated message', function () {
+  it('can construct a valid message', function () {
     const validNonTemplatedOptions = {
       from: 'sender@authorized_domain.com',
       reply_to: 'sender@authorized_domain.com',
@@ -178,12 +101,23 @@ describe('Message.validate', function () {
 
     const message = Message(validNonTemplatedOptions);
 
-    expect(message.templateName).to.be.null;
-    expect(message.templateValues).to.be.null;
     expect(message.plaintext).to.equal('Hello John Doe!');
     expect(message.htmltext).to.equal('<html><body><h1>Hello John Doe!</h1></body></html>');
+  });
 
-    expect(message.isTemplated).to.be.false;
+  it('throws an error if neither plaintext nor html text are provided', function () {
+    const invalidOptions = {
+      from: 'sender@authorized_domain.com',
+      reply_to: 'sender@authorized_domain.com',
+      to: ['recipient@host.com'],
+      cc: null,
+      bcc: null,
+      subject: 'Invalid Message',
+    };
+
+    expect(() => Message(invalidOptions)).to.throw(
+      'Message must have either plaintext or html text',
+    );
   });
 
   it('throws an error if the from address is not specified', function () {
@@ -207,7 +141,7 @@ describe('Message.validate', function () {
       html_content: '<html><body><h1>Invalid message</h1></body></html>',
     };
 
-    expect(() => Message(invalidOptions)).to.throw('To address(es) are required');
+    expect(() => Message(invalidOptions)).to.throw('One or more to addresses are required');
   });
 
   it('has sane defaults for optional fields', function () {

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -147,7 +147,17 @@ describe('Message.validate', function () {
       },
     };
 
-    expect(() => Message(validTemplatedOptions)).to.not.throw();
+    const message = Message(validTemplatedOptions);
+
+    expect(message.templateName).to.equal('welcome_email');
+    expect(message.templateValues).to.deep.equal({
+      firstName: 'John',
+      lastName: 'Doe',
+    });
+    expect(message.plaintext).to.be.undefined;
+    expect(message.htmltext).to.be.undefined;
+
+    expect(message.isTemplated).to.be.true;
   });
 
   it('can construct a valid non-templated message', function () {
@@ -162,6 +172,13 @@ describe('Message.validate', function () {
       html_content: '<html><body><h1>Hello John Doe!</h1></body></html>',
     };
 
-    expect(() => Message(validNonTemplatedOptions)).to.not.throw();
+    const message = Message(validNonTemplatedOptions);
+
+    expect(message.templateName).to.be.undefined;
+    expect(message.templateValues).to.be.undefined;
+    expect(message.plaintext).to.equal('Hello John Doe!');
+    expect(message.htmltext).to.equal('<html><body><h1>Hello John Doe!</h1></body></html>');
+
+    expect(message.isTemplated).to.be.false;
   });
 });

--- a/test/message.test.js
+++ b/test/message.test.js
@@ -85,3 +85,83 @@ describe('Message.toJSON', function () {
     expect(message.toJSON()).to.deep.equal(expectedJSON);
   });
 });
+
+describe('Message.validate', function () {
+  it('throws an error if both templated and non-templated content fields are provided', function () {
+    const invalidOptions = {
+      from: 'sender@authorized_domain.com',
+      reply_to: 'sender@authorized_domain.com',
+      to: ['recipient@host.com'],
+      cc: null,
+      bcc: null,
+      subject: 'Invalid Message',
+      text_content: 'Invalid message',
+      html_content: '<html><body><h1>Invalid message</h1></body></html>',
+      template_name: 'test_template',
+      template_values: { name: 'John' },
+    };
+
+    expect(() => Message(invalidOptions)).to.throw('Message cannot have both template and content fields');
+  });
+
+  it('throws an error if neither templated nor non-templated content fields are provided', function () {
+    const invalidOptions = {
+      from: 'sender@authorized_domain.com',
+      reply_to: 'sender@authorized_domain.com',
+      to: ['recipient@host.com'],
+      cc: null,
+      bcc: null,
+      subject: 'Invalid Message',
+    };
+
+    expect(() => Message(invalidOptions)).to.throw('Message must have either template or content fields');
+  });
+
+  it('throws an error if template values are not a valid JSON object', function () {
+    const invalidOptions = {
+      from: 'sender@authorized_domain.com',
+      reply_to: 'sender@authorized_domain.com',
+      to: ['recipient@host.com'],
+      cc: null,
+      bcc: null,
+      subject: 'Invalid Message',
+      template_name: 'test_template',
+      template_values: 'this_is_not_a_valid_json_object',
+    };
+
+    expect(() => Message(invalidOptions)).to.throw('Template values must be a valid JSON object');
+  });
+
+  it('can construct a valid templated message with valid template values', function () {
+    const validTemplatedOptions = {
+      from: 'sender@authorized_domain.com',
+      reply_to: 'sender@authorized_domain.com',
+      to: ['recipient@host.com'],
+      cc: null,
+      bcc: null,
+      subject: 'Welcome!',
+      template_name: 'welcome_email',
+      template_values: {
+        firstName: 'John',
+        lastName: 'Doe',
+      },
+    };
+
+    expect(() => Message(validTemplatedOptions)).to.not.throw();
+  });
+
+  it('can construct a valid non-templated message', function () {
+    const validNonTemplatedOptions = {
+      from: 'sender@authorized_domain.com',
+      reply_to: 'sender@authorized_domain.com',
+      to: ['recipient@host.com'],
+      cc: null,
+      bcc: null,
+      subject: 'Welcome!',
+      text_content: 'Hello John Doe!',
+      html_content: '<html><body><h1>Hello John Doe!</h1></body></html>',
+    };
+
+    expect(() => Message(validNonTemplatedOptions)).to.not.throw();
+  });
+});

--- a/test/sendMessage.test.js
+++ b/test/sendMessage.test.js
@@ -7,6 +7,7 @@ const axios = require('axios');
 
 const emailService = require('../src/service/emailService.js');
 const Message = require('../src/data/message.js');
+const TemplatedMessage = require('../src/data/templatedMessage.js');
 
 chai.use(chaiAsPromised);
 
@@ -146,7 +147,7 @@ describe('emailService.sendMessage', function () {
   });
 
   it('throws an error if the Message object is a templated message', async function () {
-    const templatedMessage = Message({
+    const templatedMessage = TemplatedMessage({
       from: 'reception@authorized_domain.com',
       reply_to: 'reception@authorized_domain.com',
       to: ['person@example.com'],
@@ -160,7 +161,7 @@ describe('emailService.sendMessage', function () {
 
     const service = emailService(testCredentials);
     await expect(service.sendMessage(templatedMessage)).to.be.rejectedWith(
-      'Message cannot be a templated message. Please use sendTemplatedMessage() instead.',
+      'Message must be a Message object',
     );
   });
 });

--- a/test/sendTemplatedMessage.test.js
+++ b/test/sendTemplatedMessage.test.js
@@ -15,37 +15,47 @@ const testCredentials = {
   apiKey: 'api-key-12345',
 };
 
-describe('emailService.sendMessage', function () {
+describe('emailService.sendTemplatedMessage', function () {
   let axiosStub;
-  const message = Message({
+  const validTemplatedMessage = Message({
     from: 'reception@authorized_domain.com',
     reply_to: 'reception@authorized_domain.com',
     to: ['person@example.com'],
     cc: ['accounts@authorized_domain.com'],
     bcc: null,
-    subject: 'Test Email',
+    subject: 'Welcome!',
     allowNonTLS: false,
     forceSecureNotification: false,
-    text_content: 'Hello world!',
-    html_content: '<html><body><h1>Hello world!</h1></body></html>',
+    template_name: 'welcome_email',
+    template_values: {
+      firstName: 'John',
+      lastName: 'Doe',
+    },
     attachments: null,
     list_unsubscribe: null,
     list_unsubscribe_post: null,
   });
 
   this.afterEach(() => {
-    axiosStub.restore();
+    if (axiosStub) {
+      axiosStub.restore();
+    }
   });
 
-  it('posts the correct JSON payload to the correct Paubox API endpoint', async function () {
+  it('posts the correct JSON payload to the correct Paubox API endpoint for a templated message', async function () {
     const expectedPayload = JSON.stringify({
       data: {
+        template_name: 'welcome_email',
+        template_values: JSON.stringify({
+          firstName: 'John',
+          lastName: 'Doe',
+        }), // Content is passed as a JSON string
         message: {
           recipients: ['person@example.com'],
           cc: ['accounts@authorized_domain.com'],
           bcc: null,
           headers: {
-            subject: 'Test Email',
+            subject: 'Welcome!',
             from: 'reception@authorized_domain.com',
             'reply-to': 'reception@authorized_domain.com',
             'List-Unsubscribe': null,
@@ -53,12 +63,6 @@ describe('emailService.sendMessage', function () {
           },
           allowNonTLS: false,
           forceSecureNotification: false,
-          content: {
-            'text/plain': 'Hello world!',
-            'text/html': Buffer.from('<html><body><h1>Hello world!</h1></body></html>').toString(
-              'base64',
-            ),
-          },
           attachments: null,
         },
       },
@@ -79,19 +83,16 @@ describe('emailService.sendMessage', function () {
     });
 
     const service = emailService(testCredentials);
-    await service.sendMessage(message);
+    await service.sendTemplatedMessage(validTemplatedMessage);
 
     expect(capturedConfig.method).to.equal('POST');
-    expect(capturedConfig.url).to.equal('/messages');
+    expect(capturedConfig.url).to.equal('/templated_messages');
     expect(capturedConfig.data).to.deep.equal(expectedPayload);
   });
 
   it('can return a successful response', async function () {
     const validResponse = {
-      sourceTrackingId: '3d38ab13-0af8-4028-bd45-52e882e0d584',
-      customHeaders: {
-        'X-Custom-Header': 'value',
-      },
+      sourceTrackingId: '36770949-12a9-1234-b12d-b27abaa123ea',
       data: 'Service OK',
     };
 
@@ -102,19 +103,19 @@ describe('emailService.sendMessage', function () {
     });
 
     const service = emailService(testCredentials);
-    const response = await service.sendMessage(message);
+    const response = await service.sendTemplatedMessage(validTemplatedMessage);
     expect(response).to.deep.equal(validResponse);
   });
 
   it('can return an error response for a bad request (HTTP 400)', async function () {
     const badRequestResponse = {
-      errors: [
-        {
-          code: 400,
-          title: 'Error Title',
-          details: 'Description of error',
-        },
-      ],
+      code: 400,
+      title: 'Invalid Request',
+      details: {
+        title: 'Missing values',
+        details: 'Length of data.message.recipients should be at least 1',
+        code: 400,
+      },
     };
 
     axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
@@ -124,8 +125,9 @@ describe('emailService.sendMessage', function () {
     });
 
     const service = emailService(testCredentials);
-    const response = await service.sendMessage(message);
-    expect(response).to.deep.equal(badRequestResponse);
+    await expect(service.sendTemplatedMessage(validTemplatedMessage)).to.be.rejectedWith(
+      badRequestResponse,
+    );
   });
 
   it('throws the API response as an error if no data is returned from the Paubox API', async function () {
@@ -142,25 +144,24 @@ describe('emailService.sendMessage', function () {
     });
 
     const service = emailService(testCredentials);
-    await expect(service.sendMessage(message)).to.be.rejectedWith(emptyResponse);
+    await expect(service.sendTemplatedMessage(validTemplatedMessage)).to.be.rejectedWith(
+      emptyResponse,
+    );
   });
 
-  it('throws an error if the Message object is a templated message', async function () {
-    const templatedMessage = Message({
+  it('throws an error if the Message object is not a templated message', async function () {
+    const nonTemplatedMessage = Message({
       from: 'reception@authorized_domain.com',
       reply_to: 'reception@authorized_domain.com',
       to: ['person@example.com'],
-      subject: 'Welcome!',
-      template_name: 'welcome_email',
-      template_values: {
-        firstName: 'John',
-        lastName: 'Doe',
-      },
+      subject: 'Test Email',
+      text_content: 'Hello world!',
+      html_content: '<html><body><h1>Hello world!</h1></body></html>',
     });
 
     const service = emailService(testCredentials);
-    await expect(service.sendMessage(templatedMessage)).to.be.rejectedWith(
-      'Message cannot be a templated message. Please use sendTemplatedMessage() instead.',
+    await expect(service.sendTemplatedMessage(nonTemplatedMessage)).to.be.rejectedWith(
+      'Message must be a templated message. Please use sendMessage() instead.',
     );
   });
 });

--- a/test/sendTemplatedMessage.test.js
+++ b/test/sendTemplatedMessage.test.js
@@ -7,6 +7,7 @@ const axios = require('axios');
 
 const emailService = require('../src/service/emailService.js');
 const Message = require('../src/data/message.js');
+const TemplatedMessage = require('../src/data/templatedMessage.js');
 
 chai.use(chaiAsPromised);
 
@@ -17,7 +18,7 @@ const testCredentials = {
 
 describe('emailService.sendTemplatedMessage', function () {
   let axiosStub;
-  const validTemplatedMessage = Message({
+  const validTemplatedMessage = TemplatedMessage({
     from: 'reception@authorized_domain.com',
     reply_to: 'reception@authorized_domain.com',
     to: ['person@example.com'],
@@ -161,7 +162,7 @@ describe('emailService.sendTemplatedMessage', function () {
 
     const service = emailService(testCredentials);
     await expect(service.sendTemplatedMessage(nonTemplatedMessage)).to.be.rejectedWith(
-      'Message must be a templated message. Please use sendMessage() instead.',
+      'Message must be a TemplatedMessage object',
     );
   });
 });


### PR DESCRIPTION
1. Updates missing documentation
2. Adds validations when constructing a Message object
3. Allows for the [sending of templated emails](https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#send-a-dynamically-templated-message).
4. Achieves feature parity with [published API docs](https://docs.paubox.com/docs/paubox_email_api/quickstart/).