### PR TITLE
Fixes incorrectly stringifying HTTP POST bodies

### DIFF
--- a/lib/service/emailService.js
+++ b/lib/service/emailService.js
@@ -86,11 +86,11 @@ class emailService {
   //
 
   async sendMessage(msg) {
-    var requestBody = JSON.stringify({
+    var requestBody = {
       data: {
         message: msg.toJSON(),
       },
-    });
+    };
     const response = await this.apiHelper.post(this.baseURL, '/messages', requestBody);
 
     if (response.data == null && response.sourceTrackingId == null && response.errors == null) {
@@ -108,11 +108,11 @@ class emailService {
   //
 
   async sendBulkMessages(messages) {
-    const requestBody = JSON.stringify({
+    const requestBody = {
       data: {
         messages: messages.map((message) => message.toJSON()),
       },
-    });
+    };
     const response = await this.apiHelper.post(this.baseURL, '/bulk_messages', requestBody);
 
     if (response.data == null && response.messages == null && response.errors == null) {

--- a/src/service/emailService.js
+++ b/src/service/emailService.js
@@ -71,11 +71,11 @@ class emailService {
   // returns a promise that resolves to the response from the API
   //
   async sendMessage(msg) {
-    var requestBody = JSON.stringify({
+    var requestBody = {
       data: {
         message: msg.toJSON(),
       },
-    });
+    };
 
     const response = await this.apiHelper.post(this.baseURL, '/messages', requestBody);
 
@@ -95,11 +95,11 @@ class emailService {
   // returns a promise that resolves to the response from the API
   //
   async sendBulkMessages(messages) {
-    const requestBody = JSON.stringify({
+    const requestBody = {
       data: {
         messages: messages.map((message) => message.toJSON()),
       },
-    });
+    };
 
     const response = await this.apiHelper.post(this.baseURL, '/bulk_messages', requestBody);
 

--- a/test/sendBulkMessages.test.js
+++ b/test/sendBulkMessages.test.js
@@ -67,7 +67,7 @@ describe('emailService.sendBulkMessages', function () {
   });
 
   it('posts the correct JSON payload to the correct Paubox API endpoint', async function () {
-    const expectedPayload = JSON.stringify({
+    const expectedPayload = {
       data: {
         messages: [
           {
@@ -126,7 +126,7 @@ describe('emailService.sendBulkMessages', function () {
           },
         ],
       },
-    });
+    };
 
     let capturedConfig;
     axiosStub = sinon.stub(axios, 'create').returns(function (config) {

--- a/test/sendMessage.test.js
+++ b/test/sendMessage.test.js
@@ -38,7 +38,7 @@ describe('emailService.sendMessage', function () {
   });
 
   it('posts the correct JSON payload to the correct Paubox API endpoint', async function () {
-    const expectedPayload = JSON.stringify({
+    const expectedPayload = {
       data: {
         message: {
           recipients: ['person@example.com'],
@@ -62,7 +62,7 @@ describe('emailService.sendMessage', function () {
           attachments: null,
         },
       },
-    });
+    };
 
     let capturedConfig;
     axiosStub = sinon.stub(axios, 'create').returns(function (config) {


### PR DESCRIPTION
### Description of Bugfix

Fixes the following errors in the sendMessage and sendBulkMessages endpoints:

```json
{
  "code": 400,
  "title": "Invalid Request",
  "details": {
    "title": "Missing required params",
    "details": "Expected 'data' with Object type.",
    "code": 400
  }
}
```

### Root cause

Incorrectly stringifying the request bodies in these two POST actions.