### PR TITLE
docs: refresh docs.paubox.com links and fix broken paubox.com marketing links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Paubox NodeJS <!-- omit from toc -->
 
-This is the official NodeJS wrapper for the [Paubox Email API](https://www.paubox.com/solutions/email-api).
+This is the official NodeJS wrapper for the [Paubox Email API](https://www.paubox.com/products/paubox-email-api).
 
 The Paubox Email API allows your application to send secure,
 compliant email via Paubox and track deliveries and opens.
@@ -50,7 +50,7 @@ npm install --save paubox-node
 
 ### Getting Paubox API Credentials
 
-You will need to have a Paubox account. You can [sign up here](https://www.paubox.com/join/see-pricing?unit=messages#paubox-email-api).
+You will need to have a Paubox account. You can [sign up here](https://www.paubox.com/pricing/paubox-email-api).
 
 Once you have an account, follow the instructions on the Rest API dashboard to verify domain ownership and generate API credentials.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The API wrapper allows you to construct and send messages.
 - [License](#license)
 - [Copyright](#copyright)
 
-Further documentation can be found at [docs.paubox.com](https://docs.paubox.com/docs/paubox_email_api/introduction/).
+Further documentation can be found at [docs.paubox.com](https://docs.paubox.com/welcome).
 
 ## Installation
 
@@ -86,7 +86,7 @@ emailService.
 
 ### Send Message
 
-Please also see the [API Documentation](https://docs.paubox.com/docs/paubox_email_api/messages#send-message).
+Please also see the [API Documentation](https://docs.paubox.com/email-api/messages).
 
 Please also see [Sending a Dynamically Templated Message](#send-a-dynamically-templated-message) for sending a message
 using a dynamic template.
@@ -170,7 +170,7 @@ var message = pbMail.message(options);
 
 #### Adding the List-Unsubscribe Header
 
-The List-Unsubscribe header provides the recipient with the option to easily opt-out of receiving any future communications. A more detailed explanation and usage guide for this header can be found at our [docs here.](https://docs.paubox.com/docs/paubox_email_api/messages/#list-unsubscribe)
+The List-Unsubscribe header provides the recipient with the option to easily opt-out of receiving any future communications. A more detailed explanation and usage guide for this header can be found at our [docs here.](https://docs.paubox.com/email-api/messages)
 
 This header can be used by adding the `list_unsubscribe: '<Email Unsubscribe Address>, <Web Unsubscribe URL'` and `list_unsubscribe_post: 'List-Unsubscribe=One-Click'` key-value pairs to the options object as follows:
 
@@ -231,7 +231,7 @@ var message = pbMail.message(options);
 
 You can add custom headers to a message by passing a `custom_headers` object to the message options.
 
-As mentioned in the [API Documentation](https://docs.paubox.com/docs/paubox_email_api/messages/#send-message), custom
+As mentioned in the [API Documentation](https://docs.paubox.com/email-api/messages), custom
 headers must be prepended with `X-` (or `x-`). Custom headers should be passed as a JSON object as a key-value pair. Example:
 
 ```json
@@ -276,7 +276,7 @@ service
 
 ### Send Bulk Messages
 
-Please also see the [API Documentation](https://docs.paubox.com/docs/paubox_email_api/messages#send-bulk-messages).
+Please also see the [API Documentation](https://docs.paubox.com/email-api/bulk-messages).
 
 > We recommend batches of 50 (fifty) or less. Source tracking ids are returned in order messages appear in the messages
 > array.
@@ -326,7 +326,7 @@ custom headers.
 
 ### Get Email Disposition
 
-Please also see the [API Documentation](https://docs.paubox.com/docs/paubox_email_api/messages#get-email-disposition).
+Please also see the [API Documentation](https://docs.paubox.com/email-api/message-receipt).
 
 The SOURCE_TRACKING_ID of a message is returned in the response of the sendMessage method. To check the status for any email, use its source tracking id and call the getEmailDisposition method of emailService:
 
@@ -345,7 +345,7 @@ service.getEmailDisposition('SOURCE_TRACKING_ID').then(function (response) {
 
 #### Create Dynamic Template
 
-Please also see the [API Documentation](https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#create-a-dynamic-template).
+Please also see the [API Documentation](https://docs.paubox.com/email-api/dynamic-templates/create).
 
 You can create a dynamic template by passing in a string, a file Buffer, or file Stream.
 
@@ -386,7 +386,7 @@ app.post('/api/create-dynamic-template', upload.single('templateFile'), async (r
 
 #### Update Dynamic Template
 
-Please also see the [API Documentation](https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#update-a-dynamic-template).
+Please also see the [API Documentation](https://docs.paubox.com/email-api/dynamic-templates/update).
 
 You can update a dynamic template's content and/or name:
 
@@ -438,7 +438,7 @@ app.patch(
 
 #### Delete Dynamic Template
 
-Please also see the [API Documentation](https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#delete-a-dynamic-template).
+Please also see the [API Documentation](https://docs.paubox.com/email-api/dynamic-templates/delete).
 
 ```javascript
 'use strict';
@@ -455,7 +455,7 @@ service.deleteDynamicTemplate(templateId).then(function (response) {
 
 #### Get Dynamic Template
 
-Please also see the [API Documentation](https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#view-one-of-your-orgs-dynamic-templates).
+Please also see the [API Documentation](https://docs.paubox.com/email-api/dynamic-templates/get).
 
 ```javascript
 'use strict';
@@ -472,7 +472,7 @@ service.getDynamicTemplate(templateId).then(function (response) {
 
 #### List Dynamic Templates
 
-Please also see the [API Documentation](https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#view-all-your-orgs-dynamic-templates).
+Please also see the [API Documentation](https://docs.paubox.com/email-api/dynamic-templates).
 
 ```javascript
 'use strict';
@@ -487,7 +487,7 @@ service.listDynamicTemplates().then(function (response) {
 
 #### Send a Dynamically Templated Message
 
-Please also see the [API Documentation](https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#send-a-dynamically-templated-message).
+Please also see the [API Documentation](https://docs.paubox.com/email-api/templated-messages).
 
 For example, assume you have a dynamic template named `welcome_email` with the following content:
 

--- a/lib/service/emailService.js
+++ b/lib/service/emailService.js
@@ -32,7 +32,7 @@ class emailService {
 
   // Get the disposition of an email message with a given sourceTrackingId
   //
-  // https://docs.paubox.com/docs/paubox_email_api/messages#get-email-disposition
+  // https://docs.paubox.com/email-api/message-receipt
   //
   // sourceTrackingId is the sourceTrackingId of the message which is returned from the sendMessage or sendBulkMessages
   // methods.
@@ -59,7 +59,7 @@ class emailService {
 
   // Send an email message
   //
-  // https://docs.paubox.com/docs/paubox_email_api/messages#send-message
+  // https://docs.paubox.com/email-api/messages
   //
   // msg is a Message object
   //
@@ -85,7 +85,7 @@ class emailService {
 
   // Send a templated email message
   //
-  // https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#send-a-dynamically-templated-message
+  // https://docs.paubox.com/email-api/templated-messages
   //
   // msg is a TemplatedMessage object
   //
@@ -120,7 +120,7 @@ class emailService {
 
   // Send multiple email messages
   //
-  // https://docs.paubox.com/docs/paubox_email_api/messages#send-bulk-messages
+  // https://docs.paubox.com/email-api/bulk-messages
   //
   // messages is an array of Message objects
   //
@@ -141,7 +141,7 @@ class emailService {
 
   // Create a dynamic template
   //
-  // https://docs.paubox.com/docs/paubox_email_api/dynamic_templates/#create-a-dynamic-template
+  // https://docs.paubox.com/email-api/dynamic-templates/create
   //
   // templateName is the name of the template
   //
@@ -168,7 +168,7 @@ class emailService {
 
   // Update a dynamic template
   //
-  // https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#update-a-dynamic-template
+  // https://docs.paubox.com/email-api/dynamic-templates/update
   //
   // templateId is the id of the template as returned from the listDynamicTemplates method
   //
@@ -208,7 +208,7 @@ class emailService {
 
   // List dynamic templates
   //
-  // https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#view-all-your-orgs-dynamic-templates
+  // https://docs.paubox.com/email-api/dynamic-templates
   //
   // returns a promise that resolves to the response from the API
   //
@@ -222,7 +222,7 @@ class emailService {
 
   // Get a dynamic template
   //
-  // https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#view-one-of-your-orgs-dynamic-templates
+  // https://docs.paubox.com/email-api/dynamic-templates/get
   //
   // templateId is the id of the template as returned from the listDynamicTemplates method
   //
@@ -245,7 +245,7 @@ class emailService {
 
   // Delete a dynamic template
   //
-  // https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#delete-a-dynamic-template
+  // https://docs.paubox.com/email-api/dynamic-templates/delete
   //
   // templateId is the id of the template as returned from the listDynamicTemplates method
   //

--- a/src/service/emailService.js
+++ b/src/service/emailService.js
@@ -35,7 +35,7 @@ class emailService {
 
   // Get the disposition of an email message with a given sourceTrackingId
   //
-  // https://docs.paubox.com/docs/paubox_email_api/messages#get-email-disposition
+  // https://docs.paubox.com/email-api/message-receipt
   //
   // sourceTrackingId is the sourceTrackingId of the message which is returned from the sendMessage or sendBulkMessages
   // methods.
@@ -64,7 +64,7 @@ class emailService {
 
   // Send an email message
   //
-  // https://docs.paubox.com/docs/paubox_email_api/messages#send-message
+  // https://docs.paubox.com/email-api/messages
   //
   // msg is a Message object
   //
@@ -93,7 +93,7 @@ class emailService {
 
   // Send a templated email message
   //
-  // https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#send-a-dynamically-templated-message
+  // https://docs.paubox.com/email-api/templated-messages
   //
   // msg is a TemplatedMessage object
   //
@@ -132,7 +132,7 @@ class emailService {
 
   // Send multiple email messages
   //
-  // https://docs.paubox.com/docs/paubox_email_api/messages#send-bulk-messages
+  // https://docs.paubox.com/email-api/bulk-messages
   //
   // messages is an array of Message objects
   //
@@ -156,7 +156,7 @@ class emailService {
 
   // Create a dynamic template
   //
-  // https://docs.paubox.com/docs/paubox_email_api/dynamic_templates/#create-a-dynamic-template
+  // https://docs.paubox.com/email-api/dynamic-templates/create
   //
   // templateName is the name of the template
   //
@@ -186,7 +186,7 @@ class emailService {
 
   // Update a dynamic template
   //
-  // https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#update-a-dynamic-template
+  // https://docs.paubox.com/email-api/dynamic-templates/update
   //
   // templateId is the id of the template as returned from the listDynamicTemplates method
   //
@@ -230,7 +230,7 @@ class emailService {
 
   // List dynamic templates
   //
-  // https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#view-all-your-orgs-dynamic-templates
+  // https://docs.paubox.com/email-api/dynamic-templates
   //
   // returns a promise that resolves to the response from the API
   //
@@ -246,7 +246,7 @@ class emailService {
 
   // Get a dynamic template
   //
-  // https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#view-one-of-your-orgs-dynamic-templates
+  // https://docs.paubox.com/email-api/dynamic-templates/get
   //
   // templateId is the id of the template as returned from the listDynamicTemplates method
   //
@@ -274,7 +274,7 @@ class emailService {
 
   // Delete a dynamic template
   //
-  // https://docs.paubox.com/docs/paubox_email_api/dynamic_templates#delete-a-dynamic-template
+  // https://docs.paubox.com/email-api/dynamic-templates/delete
   //
   // templateId is the id of the template as returned from the listDynamicTemplates method
   //


### PR DESCRIPTION
## Summary

Refreshes every external URL in the repo that was either stale or broken. Two related cleanups:

1. **Rewrites every `docs.paubox.com` reference** from the legacy Swagger-style URL structure (`/docs/paubox_email_api/<page>#<anchor>`) to the live Mintlify structure (`/email-api/<page>`). Every target URL was verified to return 200 against `docs.paubox.com` before being committed.
2. **Fixes two broken/stale `paubox.com` marketing links** in `README.md`:
   - Sign-up link → `/join/see-pricing` (404) → updated to `/pricing/paubox-email-api` (200).
   - Intro link → `/solutions/email-api` (301 redirect) → updated to the direct `/products/paubox-email-api`.

- **32 URL substitutions** across 3 files (README.md, src/service/emailService.js, lib/service/emailService.js).
- **0 flagged** — every legacy URL had a sensible live target.
- No code changes; only markdown links and `//` doc-comment URLs.

## docs.paubox.com mapping applied

| Old URL (in repo) | New URL |
|---|---|
| `…/docs/paubox_email_api/introduction/` | `https://docs.paubox.com/welcome` |
| `…/docs/paubox_email_api/messages#send-message` | `https://docs.paubox.com/email-api/messages` |
| `…/docs/paubox_email_api/messages/#send-message` | `https://docs.paubox.com/email-api/messages` |
| `…/docs/paubox_email_api/messages/#list-unsubscribe` | `https://docs.paubox.com/email-api/messages` |
| `…/docs/paubox_email_api/messages#send-bulk-messages` | `https://docs.paubox.com/email-api/bulk-messages` |
| `…/docs/paubox_email_api/messages#get-email-disposition` | `https://docs.paubox.com/email-api/message-receipt` |
| `…/docs/paubox_email_api/dynamic_templates#create-a-dynamic-template` | `https://docs.paubox.com/email-api/dynamic-templates/create` |
| `…/docs/paubox_email_api/dynamic_templates/#create-a-dynamic-template` | `https://docs.paubox.com/email-api/dynamic-templates/create` |
| `…/docs/paubox_email_api/dynamic_templates#update-a-dynamic-template` | `https://docs.paubox.com/email-api/dynamic-templates/update` |
| `…/docs/paubox_email_api/dynamic_templates#delete-a-dynamic-template` | `https://docs.paubox.com/email-api/dynamic-templates/delete` |
| `…/docs/paubox_email_api/dynamic_templates#view-one-of-your-orgs-dynamic-templates` | `https://docs.paubox.com/email-api/dynamic-templates/get` |
| `…/docs/paubox_email_api/dynamic_templates#view-all-your-orgs-dynamic-templates` | `https://docs.paubox.com/email-api/dynamic-templates` |
| `…/docs/paubox_email_api/dynamic_templates#send-a-dynamically-templated-message` | `https://docs.paubox.com/email-api/templated-messages` |

## paubox.com marketing link fixes

| Old URL | New URL | Reason |
|---|---|---|
| `https://www.paubox.com/solutions/email-api` | `https://www.paubox.com/products/paubox-email-api` | Source was a 301 redirect; point directly at the canonical page. |
| `https://www.paubox.com/join/see-pricing?unit=messages#paubox-email-api` | `https://www.paubox.com/pricing/paubox-email-api` | Source was a hard 404; `/join/*` path no longer exists. |

## Per-file counts

| File | Replacements |
|---|---|
| `README.md` | 14 |
| `src/service/emailService.js` | 9 |
| `lib/service/emailService.js` | 9 |

`lib/` is the transpiled distribution shipped in the npm package, so it was updated to stay in sync with `src/`.

## Other links checked, all healthy (200)

Every remaining external URL in the repo was probed and returns 200: the GitHub repo/PR links in CHANGELOG and CONTRIBUTING, the nvm install script, the Apache LICENSE URL, the README banner image, and the `http://www.paubox.com` homepage in `package.json` (auto-upgrades to https). The `example.com` unsubscribe URL in the README code sample and the `<USERNAME>`-templated API base URL are intentional documentation placeholders.

## Notes / judgment calls

- The original brief's canonical table listed `https://docs.paubox.com/eml-api/bulk-messages` for bulk messages. Treated as a typo; used `email-api/bulk-messages` (matches every other row and Pattern C's explicit mapping). Live URL verified.
- The legacy `messages/#list-unsubscribe` anchor has no dedicated stable anchor on the new Mintlify page, but the messages page does document the `List-Unsubscribe` and `List-Unsubscribe-Post` headers in its OpenAPI schema. Rewrote to plain `email-api/messages` — readers will see the headers in the schema below the fold.
- All canonical target URLs verified live via curl/WebFetch before substitution.

## Test plan

- [ ] Render README on the PR diff view and spot-check 3–4 doc links — confirm each lands on the right Mintlify or paubox.com page.
- [ ] `rg 'docs\.paubox\.com' .` shows only canonical URLs (no `/docs/paubox_email_api/` remnants).
- [ ] Click the README sign-up link and intro link in rendered preview to confirm 200.
- [ ] Confirm `lib/` and `src/` URL comments stayed in sync (same 9 canonical URLs in the same comment positions).
- [ ] Do not merge — leave open for human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
