### PR TITLE
Add Paubox Forms API support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ index.js                 # Public exports: emailService, formService, message, t
 ### formService
 
 - No credentials required — these are public endpoints called by form respondents.
-- Base URL: `https://next.paubox.com`.
+- Base URL: `https://apx.paubox.com/forms`.
 - Uses `axios.create` directly (no `apiHelper`) since there is no auth header.
 - `getForm` validates that the response contains an `id` field before returning.
 - `submitForm` sends JSON and resolves to `null` on HTTP 201 (no response body).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# Paubox Node — Codebase Guide
+
+## Project overview
+
+`paubox-node` is the official Node.js SDK for the Paubox platform. It exposes two services:
+
+- **emailService** — authenticated REST client for the Paubox Email API (`api.paubox.net/v1/`). Sends messages, tracks delivery, and manages dynamic Handlebars templates.
+- **formService** — unauthenticated REST client for the Paubox Forms API (`next.paubox.com`). Fetches form definitions and submits form responses.
+
+## Repository layout
+
+```
+src/
+  data/
+    baseMessage.js       # Shared utilities (safeBase64Encode, parseBool)
+    message.js           # Email message class — validates & serialises to JSON
+    templatedMessage.js  # Templated email class (extends base message)
+  service/
+    apiHelper.js         # Axios wrapper with Authorization header injection
+    emailService.js      # Email + template API methods
+    formService.js       # Forms API methods (no auth)
+lib/                     # Babel-compiled output of src/ — not edited by hand
+test/                    # Mocha test suite (one file per public method)
+index.js                 # Public exports: emailService, formService, message, templatedMessage
+```
+
+## Architecture
+
+### emailService
+
+- Constructor requires `apiUsername` and `apiKey` (or env vars `API_USERNAME` / `API_KEY`).
+- All requests use `apiHelper`, which injects `Authorization: Token token=<apiKey>`.
+- Base URL: `https://api.paubox.net/v1/<apiUsername>/`.
+- Dynamic template uploads use `FormData` (multipart); all other requests are JSON.
+- Response validation: methods inspect well-known fields and throw the raw response if unexpected.
+
+### formService
+
+- No credentials required — these are public endpoints called by form respondents.
+- Base URL: `https://next.paubox.com`.
+- Uses `axios.create` directly (no `apiHelper`) since there is no auth header.
+- `getForm` validates that the response contains an `id` field before returning.
+- `submitForm` sends JSON and resolves to `null` on HTTP 201 (no response body).
+- Supports file attachments up to 250 MB via base64-encoded content in the request body.
+
+### Data models
+
+- `message` / `templatedMessage` are value objects. Construction validates required fields and `toJSON()` serialises to the shape the API expects.
+- `baseMessage` provides shared helpers used by both classes.
+
+## Development commands
+
+```bash
+npm test             # Run full Mocha test suite
+npm run test:watch   # Re-run tests on file changes
+npm run lint         # ESLint
+npm run format       # Prettier (writes in place)
+npm run build        # lint → format → clean lib/ → Babel compile → prettier lib/
+```
+
+> **Build note:** the lint step checks that all `require()` targets in `index.js` exist in `lib/`. If you add a new service file, run `npm run build:babel` once to seed `lib/` before running the full `npm run build`.
+
+## Testing patterns
+
+- Framework: Mocha + Chai (`chai-as-promised`) + Sinon.
+- All HTTP calls are stubbed via `sinon.stub(axios, 'create')`.
+- Tests import directly from `src/` (not from `lib/`), so no build step is needed to run them.
+- Each public method has its own test file under `test/`.
+- Test files cover: happy path, input validation errors, API error responses, and unexpected response shapes.
+
+## Adding a new endpoint
+
+1. Add the method to the relevant service in `src/service/`.
+2. Add a test file to `test/`.
+3. If it is a new service, export it from `index.js` and run `npm run build:babel` before `npm run build`.
+4. Document the method in `api.md` and add a usage example to `README.md`.
+
+## Code style
+
+- CommonJS (`'use strict'` + `require`/`module.exports`).
+- Async/await throughout service methods.
+- ESLint + Prettier enforced; run `npm run build` to check before committing.
+- No inline comments except where the behaviour is non-obvious.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ The API wrapper allows you to construct and send messages.
     - [Get Dynamic Template](#get-dynamic-template)
     - [List Dynamic Templates](#list-dynamic-templates)
     - [Send a Dynamically Templated Message](#send-a-dynamically-templated-message)
+  - [Paubox Forms](#paubox-forms)
+    - [Get Form](#get-form)
+    - [Submit Form](#submit-form)
 - [Supported Node Versions](#supported-node-versions)
 - [Contributing](#contributing)
 - [License](#license)
@@ -532,6 +535,96 @@ service
 ```
 
 **Note**: Custom headers are currently not supported for templated messages.
+
+### Paubox Forms
+
+Paubox Forms endpoints are **public** — no API key or username is required. Use `pbMail.formService()` to get a service instance.
+
+#### Get Form
+
+Please also see the [API Documentation](https://docs.paubox.com/forms/get-form).
+
+Returns the full form definition (HTML, JSON schema, CSS) for a given form. This is typically called before rendering a form embed.
+
+```javascript
+'use strict';
+require('dotenv').config();
+const pbMail = require('paubox-node');
+const service = pbMail.formService();
+
+const formId = '550e8400-e29b-41d4-a716-446655440000';
+
+service
+  .getForm(formId)
+  .then((form) => {
+    console.log('Get Form Response: ' + JSON.stringify(form));
+    // form.form_html contains the renderable HTML
+    // form.form_json contains the field schema
+  })
+  .catch((error) => {
+    console.log('Error in Get Form: ' + JSON.stringify(error));
+  });
+```
+
+#### Submit Form
+
+Please also see the [API Documentation](https://docs.paubox.com/forms/submit-form).
+
+Submits a respondent's answers for a form. The keys in `formData` should match the form's field schema (`form_json`). Returns `null` on success (HTTP 201 No Content). Maximum request size is 250 MB to support file attachments.
+
+```javascript
+'use strict';
+require('dotenv').config();
+const pbMail = require('paubox-node');
+const service = pbMail.formService();
+
+const formId = '550e8400-e29b-41d4-a716-446655440000';
+
+const formData = {
+  first_name: 'Jane',
+  last_name: 'Smith',
+  email: 'jane@example.com',
+};
+
+service
+  .submitForm(formId, formData)
+  .then(() => {
+    console.log('Form submitted successfully');
+  })
+  .catch((error) => {
+    console.log('Error submitting form: ' + JSON.stringify(error));
+  });
+```
+
+To submit a form with file attachments, pass an array of attachment objects with `name` (filename) and `content` (base64-encoded file content):
+
+```javascript
+'use strict';
+const fs = require('fs');
+require('dotenv').config();
+const pbMail = require('paubox-node');
+const service = pbMail.formService();
+
+const formId = '550e8400-e29b-41d4-a716-446655440000';
+
+const formData = { first_name: 'Jane' };
+
+const attachments = [
+  {
+    name: 'consent.pdf',
+    content: fs.readFileSync('./consent.pdf').toString('base64'),
+  },
+];
+
+service
+  .submitForm(formId, formData, attachments)
+  .then(() => {
+    console.log('Form submitted successfully');
+  })
+  .catch((error) => {
+    console.log('Error submitting form: ' + JSON.stringify(error));
+  });
+```
 
 ## Supported Node Versions
 

--- a/api.md
+++ b/api.md
@@ -153,7 +153,7 @@ const pbMail = require('paubox-node');
 const service = pbMail.formService();
 ```
 
-Base URL: `https://next.paubox.com`
+Base URL: `https://apx.paubox.com/forms`
 
 ---
 

--- a/api.md
+++ b/api.md
@@ -1,0 +1,262 @@
+# Paubox Node API Reference
+
+This document describes all public methods exposed by `paubox-node`.
+
+---
+
+## emailService
+
+Create a service instance to send email and manage dynamic templates.
+
+```javascript
+const pbMail = require('paubox-node');
+const service = pbMail.emailService({ apiUsername: '...', apiKey: '...' });
+```
+
+Credentials can also be loaded from environment variables `API_USERNAME` and `API_KEY`.
+
+---
+
+### sendMessage(message)
+
+Send a single email message.
+
+| Parameter | Type      | Description                       |
+| --------- | --------- | --------------------------------- |
+| `message` | `Message` | A `Message` instance (see below). |
+
+**Returns:** `Promise<object>` — the Paubox API response.
+
+**Docs:** https://docs.paubox.com/email-api/messages
+
+---
+
+### sendBulkMessages(messages)
+
+Send multiple email messages in a single request.
+
+| Parameter  | Type        | Description                   |
+| ---------- | ----------- | ----------------------------- |
+| `messages` | `Message[]` | Array of `Message` instances. |
+
+> Recommended batch size: 50 or fewer. Source tracking IDs are returned in the same order as the input array.
+
+**Returns:** `Promise<object>` — the Paubox API response.
+
+**Docs:** https://docs.paubox.com/email-api/bulk-messages
+
+---
+
+### sendTemplatedMessage(message)
+
+Send an email using a dynamic template.
+
+| Parameter | Type               | Description                                |
+| --------- | ------------------ | ------------------------------------------ |
+| `message` | `TemplatedMessage` | A `TemplatedMessage` instance (see below). |
+
+**Returns:** `Promise<object>` — the Paubox API response.
+
+**Docs:** https://docs.paubox.com/email-api/templated-messages
+
+---
+
+### getEmailDisposition(sourceTrackingId)
+
+Get the delivery and open status of a previously sent message.
+
+| Parameter          | Type     | Description                                             |
+| ------------------ | -------- | ------------------------------------------------------- |
+| `sourceTrackingId` | `string` | The ID returned by `sendMessage` or `sendBulkMessages`. |
+
+**Returns:** `Promise<object>` — the message receipt object. If `openedStatus` is not set, it defaults to `"unopened"`.
+
+**Docs:** https://docs.paubox.com/email-api/message-receipt
+
+---
+
+### createDynamicTemplate(templateName, templateContent)
+
+Create a new dynamic (Handlebars) template.
+
+| Parameter         | Type                         | Description                      |
+| ----------------- | ---------------------------- | -------------------------------- |
+| `templateName`    | `string`                     | Name for the template.           |
+| `templateContent` | `string \| Buffer \| Stream` | Template body (Handlebars HTML). |
+
+**Returns:** `Promise<object>` — the Paubox API response.
+
+**Docs:** https://docs.paubox.com/email-api/dynamic-templates/create
+
+---
+
+### updateDynamicTemplate(templateId, templateName, templateContent)
+
+Update an existing dynamic template. At least one of `templateName` or `templateContent` must be provided.
+
+| Parameter         | Type                                 | Description                                       |
+| ----------------- | ------------------------------------ | ------------------------------------------------- |
+| `templateId`      | `number`                             | ID of the template (from `listDynamicTemplates`). |
+| `templateName`    | `string \| null`                     | New name, or `null` to leave unchanged.           |
+| `templateContent` | `string \| Buffer \| Stream \| null` | New body, or `null` to leave unchanged.           |
+
+**Returns:** `Promise<object>` — the Paubox API response.
+
+**Docs:** https://docs.paubox.com/email-api/dynamic-templates/update
+
+---
+
+### deleteDynamicTemplate(templateId)
+
+Delete a dynamic template.
+
+| Parameter    | Type     | Description                                       |
+| ------------ | -------- | ------------------------------------------------- |
+| `templateId` | `number` | ID of the template (from `listDynamicTemplates`). |
+
+**Returns:** `Promise<object>` — the Paubox API response.
+
+**Docs:** https://docs.paubox.com/email-api/dynamic-templates/delete
+
+---
+
+### getDynamicTemplate(templateId)
+
+Get a single dynamic template by ID.
+
+| Parameter    | Type     | Description                                       |
+| ------------ | -------- | ------------------------------------------------- |
+| `templateId` | `number` | ID of the template (from `listDynamicTemplates`). |
+
+**Returns:** `Promise<object>` — the template object (`id`, `name`, `api_customer_id`, `body`, `created_at`, `updated_at`, `metadata`).
+
+**Docs:** https://docs.paubox.com/email-api/dynamic-templates/get
+
+---
+
+### listDynamicTemplates()
+
+List all dynamic templates for the account.
+
+**Returns:** `Promise<object[]>` — array of template summary objects.
+
+**Docs:** https://docs.paubox.com/email-api/dynamic-templates
+
+---
+
+## formService
+
+Create a service instance for Paubox Forms. **No API credentials required.**
+
+```javascript
+const pbMail = require('paubox-node');
+const service = pbMail.formService();
+```
+
+Base URL: `https://next.paubox.com`
+
+---
+
+### getForm(formId)
+
+Get the full form definition for a given form UUID. Used by form embeds before rendering.
+
+| Parameter | Type     | Description                   |
+| --------- | -------- | ----------------------------- |
+| `formId`  | `string` | UUID of the form to retrieve. |
+
+**Returns:** `Promise<object>` — the form object:
+
+| Field                          | Type      | Description                                  |
+| ------------------------------ | --------- | -------------------------------------------- |
+| `id`                           | `string`  | Form UUID.                                   |
+| `title`                        | `string`  | Form title.                                  |
+| `description`                  | `string?` | Optional description.                        |
+| `form_html`                    | `string?` | Renderable HTML for the form.                |
+| `form_json`                    | `object?` | JSON schema describing form fields.          |
+| `form_css`                     | `string?` | CSS styles for the form.                     |
+| `vanity_url`                   | `string?` | Custom URL slug.                             |
+| `version`                      | `number`  | Form version number.                         |
+| `active`                       | `boolean` | Whether the form accepts submissions.        |
+| `customer_id`                  | `number`  | Owning customer ID.                          |
+| `signable`                     | `boolean` | Whether the form includes a signature field. |
+| `signature_confirmation_label` | `string?` | Label for signature confirmation.            |
+| `submission_count`             | `number`  | Total submissions received.                  |
+| `type`                         | `string?` | Form type classification.                    |
+| `deleted`                      | `boolean` | Whether the form has been deleted.           |
+| `archived`                     | `boolean` | Whether the form has been archived.          |
+| `created_at`                   | `string`  | ISO 8601 creation timestamp.                 |
+| `updated_at`                   | `string`  | ISO 8601 last-updated timestamp.             |
+
+**Throws:** Rejects with the API error if the form is not found (HTTP 404).
+
+**Docs:** https://docs.paubox.com/forms/get-form
+
+---
+
+### submitForm(formId, formData, attachments)
+
+Submit a respondent's answers for a form. Maximum request size is 250 MB.
+
+| Parameter     | Type        | Description                                                     |
+| ------------- | ----------- | --------------------------------------------------------------- |
+| `formId`      | `string`    | UUID of the form being submitted.                               |
+| `formData`    | `object`    | Key-value pairs matching the form's field schema (`form_json`). |
+| `attachments` | `object[]?` | Optional array of file attachments (see below).                 |
+
+Each attachment object:
+
+| Field     | Type     | Description                      |
+| --------- | -------- | -------------------------------- |
+| `name`    | `string` | Filename (e.g. `"consent.pdf"`). |
+| `content` | `string` | Base64-encoded file content.     |
+
+**Returns:** `Promise<null>` — resolves to `null` on success (HTTP 201 No Content).
+
+**Throws:** Rejects with the API error on HTTP 400 (missing `form_data`) or 404 (form not found).
+
+**Docs:** https://docs.paubox.com/forms/submit-form
+
+---
+
+## message(options)
+
+Construct an email message.
+
+```javascript
+const msg = pbMail.message(options);
+```
+
+| Option                    | Type       | Required | Description                                                                     |
+| ------------------------- | ---------- | -------- | ------------------------------------------------------------------------------- |
+| `from`                    | `string`   | Yes      | Sender address.                                                                 |
+| `to`                      | `string[]` | Yes      | Recipient addresses.                                                            |
+| `subject`                 | `string`   | No       | Email subject line.                                                             |
+| `text_content`            | `string`   | No\*     | Plain-text body. At least one of `text_content` or `html_content` is required.  |
+| `html_content`            | `string`   | No\*     | HTML body. At least one of `text_content` or `html_content` is required.        |
+| `reply_to`                | `string`   | No       | Reply-to address.                                                               |
+| `cc`                      | `string[]` | No       | CC addresses.                                                                   |
+| `bcc`                     | `string[]` | No       | BCC addresses.                                                                  |
+| `allowNonTLS`             | `boolean`  | No       | Allow delivery over non-TLS connections (default: `false`).                     |
+| `forceSecureNotification` | `boolean`  | No       | Force secure portal notification instead of inline delivery.                    |
+| `list_unsubscribe`        | `string`   | No       | `List-Unsubscribe` header value.                                                |
+| `list_unsubscribe_post`   | `string`   | No       | `List-Unsubscribe-Post` header value.                                           |
+| `custom_headers`          | `object`   | No       | Key-value pairs; keys must start with `X-` or `x-`.                             |
+| `attachments`             | `object[]` | No       | Array of `{ fileName, contentType, content }` objects (base64-encoded content). |
+
+---
+
+## templatedMessage(options)
+
+Construct a templated email message.
+
+```javascript
+const msg = pbMail.templatedMessage(options);
+```
+
+Accepts the same options as `message()`, plus:
+
+| Option            | Type     | Required | Description                                                           |
+| ----------------- | -------- | -------- | --------------------------------------------------------------------- |
+| `template_name`   | `string` | Yes      | Name of the dynamic template to use.                                  |
+| `template_values` | `object` | Yes      | Key-value pairs substituted into the template's Handlebars variables. |

--- a/index.js
+++ b/index.js
@@ -1,9 +1,14 @@
 const emailService = require('./lib/service/emailService.js');
+const formService = require('./lib/service/formService.js');
 const message = require('./lib/data/message.js');
 const templatedMessage = require('./lib/data/templatedMessage.js');
 
 module.exports.emailService = function (config) {
   return new emailService(config);
+};
+
+module.exports.formService = function () {
+  return new formService();
 };
 
 module.exports.message = function (options) {

--- a/lib/service/formService.js
+++ b/lib/service/formService.js
@@ -3,7 +3,7 @@
 const axios = require('axios');
 class formService {
   constructor() {
-    this.baseURL = 'https://next.paubox.com';
+    this.baseURL = 'https://apx.paubox.com/forms';
   }
 
   // Get the full form definition (HTML, JSON schema, CSS) for a given form.

--- a/lib/service/formService.js
+++ b/lib/service/formService.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const axios = require('axios');
+class formService {
+  constructor() {
+    this.baseURL = 'https://next.paubox.com';
+  }
+
+  // Get the full form definition (HTML, JSON schema, CSS) for a given form.
+  //
+  // https://docs.paubox.com/forms/get-form
+  //
+  // No authentication required.
+  //
+  // formId is the UUID of the form to retrieve
+  //
+  // returns a promise that resolves to the form object
+  //
+  async getForm(formId) {
+    if (!formId) {
+      throw new Error('formId is required');
+    }
+    const axiosInstance = axios.create({
+      baseURL: this.baseURL,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    const response = await axiosInstance({
+      method: 'GET',
+      url: `/public/form_data/${formId}`,
+    });
+    const form = response.data;
+    if (!form || !form.id) {
+      throw form;
+    }
+    return form;
+  }
+
+  // Submit a respondent's answers for a form.
+  //
+  // https://docs.paubox.com/forms/submit-form
+  //
+  // No authentication required. Maximum request size is 250 MB.
+  //
+  // formId is the UUID of the form being submitted
+  //
+  // formData is a key-value object matching the form's field schema (form_json)
+  //
+  // attachments is an optional array of objects with name (filename) and
+  // content (base64-encoded file content) fields
+  //
+  // returns a promise that resolves to null on success (201 No Content)
+  //
+  async submitForm(formId, formData, attachments = null) {
+    if (!formId) {
+      throw new Error('formId is required');
+    }
+    if (!formData || typeof formData !== 'object' || Array.isArray(formData)) {
+      throw new Error('formData is required and must be an object');
+    }
+    const requestBody = {
+      form_data: formData,
+    };
+    if (attachments && Array.isArray(attachments) && attachments.length > 0) {
+      requestBody.attachments = attachments;
+    }
+    const axiosInstance = axios.create({
+      baseURL: this.baseURL,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      maxBodyLength: 250 * 1024 * 1024,
+      maxContentLength: 250 * 1024 * 1024,
+    });
+    await axiosInstance({
+      method: 'POST',
+      url: `/api/forms/${formId}/submissions`,
+      data: requestBody,
+    });
+    return null;
+  }
+}
+module.exports = function () {
+  return new formService();
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "paubox-node",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "paubox-node",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "1.12.0",

--- a/src/service/formService.js
+++ b/src/service/formService.js
@@ -4,7 +4,7 @@ const axios = require('axios');
 
 class formService {
   constructor() {
-    this.baseURL = 'https://next.paubox.com';
+    this.baseURL = 'https://apx.paubox.com/forms';
   }
 
   // Get the full form definition (HTML, JSON schema, CSS) for a given form.

--- a/src/service/formService.js
+++ b/src/service/formService.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const axios = require('axios');
+
+class formService {
+  constructor() {
+    this.baseURL = 'https://next.paubox.com';
+  }
+
+  // Get the full form definition (HTML, JSON schema, CSS) for a given form.
+  //
+  // https://docs.paubox.com/forms/get-form
+  //
+  // No authentication required.
+  //
+  // formId is the UUID of the form to retrieve
+  //
+  // returns a promise that resolves to the form object
+  //
+  async getForm(formId) {
+    if (!formId) {
+      throw new Error('formId is required');
+    }
+
+    const axiosInstance = axios.create({
+      baseURL: this.baseURL,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const response = await axiosInstance({
+      method: 'GET',
+      url: `/public/form_data/${formId}`,
+    });
+
+    const form = response.data;
+
+    if (!form || !form.id) {
+      throw form;
+    }
+
+    return form;
+  }
+
+  // Submit a respondent's answers for a form.
+  //
+  // https://docs.paubox.com/forms/submit-form
+  //
+  // No authentication required. Maximum request size is 250 MB.
+  //
+  // formId is the UUID of the form being submitted
+  //
+  // formData is a key-value object matching the form's field schema (form_json)
+  //
+  // attachments is an optional array of objects with name (filename) and
+  // content (base64-encoded file content) fields
+  //
+  // returns a promise that resolves to null on success (201 No Content)
+  //
+  async submitForm(formId, formData, attachments = null) {
+    if (!formId) {
+      throw new Error('formId is required');
+    }
+    if (!formData || typeof formData !== 'object' || Array.isArray(formData)) {
+      throw new Error('formData is required and must be an object');
+    }
+
+    const requestBody = { form_data: formData };
+
+    if (attachments && Array.isArray(attachments) && attachments.length > 0) {
+      requestBody.attachments = attachments;
+    }
+
+    const axiosInstance = axios.create({
+      baseURL: this.baseURL,
+      headers: { 'Content-Type': 'application/json' },
+      maxBodyLength: 250 * 1024 * 1024,
+      maxContentLength: 250 * 1024 * 1024,
+    });
+
+    await axiosInstance({
+      method: 'POST',
+      url: `/api/forms/${formId}/submissions`,
+      data: requestBody,
+    });
+
+    return null;
+  }
+}
+
+module.exports = function () {
+  return new formService();
+};

--- a/test/getForm.test.js
+++ b/test/getForm.test.js
@@ -1,0 +1,82 @@
+const chai = require('chai');
+const { expect } = chai;
+const chaiAsPromised = require('chai-as-promised').default;
+
+const sinon = require('sinon');
+const axios = require('axios');
+
+const formService = require('../src/service/formService.js');
+
+chai.use(chaiAsPromised);
+
+const formId = '550e8400-e29b-41d4-a716-446655440000';
+
+const validFormResponse = {
+  id: formId,
+  title: 'Patient Intake Form',
+  description: 'Please complete before your appointment.',
+  form_json: {},
+  form_html: '<form>...</form>',
+  form_css: 'form { font-family: sans-serif; }',
+  vanity_url: null,
+  version: 1,
+  active: true,
+  customer_id: 123,
+  signable: false,
+  signature_confirmation_label: null,
+  submission_count: 42,
+  type: null,
+  deleted: false,
+  archived: false,
+  created_at: '2024-01-15T10:30:00Z',
+  updated_at: '2024-06-01T08:00:00Z',
+};
+
+describe('formService.getForm', function () {
+  let axiosStub;
+
+  this.afterEach(() => {
+    axiosStub.restore();
+  });
+
+  it('can get a form', async function () {
+    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
+      return Promise.resolve({ data: validFormResponse });
+    });
+
+    const service = formService();
+    const response = await service.getForm(formId);
+    expect(response).to.deep.equal(validFormResponse);
+  });
+
+  it('throws an error if formId is not provided', async function () {
+    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
+      return Promise.resolve({ data: validFormResponse });
+    });
+
+    const service = formService();
+    await expect(service.getForm()).to.be.rejectedWith('formId is required');
+  });
+
+  it('throws the response if form is not found', async function () {
+    const errorMessage = 'Request failed with status code 404';
+
+    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
+      return Promise.reject({ message: errorMessage, response: { status: 404 } });
+    });
+
+    const service = formService();
+    await expect(service.getForm(formId)).to.be.rejectedWith(errorMessage);
+  });
+
+  it('throws the response if an unexpected response is returned', async function () {
+    const unexpectedResponse = { this: 'is not what we expected' };
+
+    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
+      return Promise.resolve({ data: unexpectedResponse });
+    });
+
+    const service = formService();
+    await expect(service.getForm(formId)).to.be.rejected;
+  });
+});

--- a/test/submitForm.test.js
+++ b/test/submitForm.test.js
@@ -1,0 +1,114 @@
+const chai = require('chai');
+const { expect } = chai;
+const chaiAsPromised = require('chai-as-promised').default;
+
+const sinon = require('sinon');
+const axios = require('axios');
+
+const formService = require('../src/service/formService.js');
+
+chai.use(chaiAsPromised);
+
+const formId = '550e8400-e29b-41d4-a716-446655440000';
+
+describe('formService.submitForm', function () {
+  let axiosStub;
+
+  this.afterEach(() => {
+    axiosStub.restore();
+  });
+
+  it('can submit a form with text fields', async function () {
+    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
+      return Promise.resolve({ data: null });
+    });
+
+    const service = formService();
+    const formData = { first_name: 'Jane', last_name: 'Smith', email: 'jane@example.com' };
+    const response = await service.submitForm(formId, formData);
+    expect(response).to.be.null;
+  });
+
+  it('can submit a form with attachments', async function () {
+    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
+      return Promise.resolve({ data: null });
+    });
+
+    const service = formService();
+    const formData = { first_name: 'Jane' };
+    const attachments = [{ name: 'consent.pdf', content: 'JVBERi0xLjQ...' }];
+    const response = await service.submitForm(formId, formData, attachments);
+    expect(response).to.be.null;
+  });
+
+  it('throws an error if formId is not provided', async function () {
+    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
+      return Promise.resolve({ data: null });
+    });
+
+    const service = formService();
+    await expect(service.submitForm(null, { first_name: 'Jane' })).to.be.rejectedWith(
+      'formId is required',
+    );
+  });
+
+  it('throws an error if formData is not provided', async function () {
+    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
+      return Promise.resolve({ data: null });
+    });
+
+    const service = formService();
+    await expect(service.submitForm(formId)).to.be.rejectedWith(
+      'formData is required and must be an object',
+    );
+  });
+
+  it('throws an error if formData is not an object', async function () {
+    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
+      return Promise.resolve({ data: null });
+    });
+
+    const service = formService();
+    await expect(service.submitForm(formId, 'not an object')).to.be.rejectedWith(
+      'formData is required and must be an object',
+    );
+  });
+
+  it('throws an error if formData is an array', async function () {
+    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
+      return Promise.resolve({ data: null });
+    });
+
+    const service = formService();
+    await expect(service.submitForm(formId, ['field1', 'field2'])).to.be.rejectedWith(
+      'formData is required and must be an object',
+    );
+  });
+
+  it('throws the response if the form is not found', async function () {
+    const errorMessage = 'Request failed with status code 404';
+
+    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
+      return Promise.reject({ message: errorMessage, response: { status: 404 } });
+    });
+
+    const service = formService();
+    await expect(service.submitForm(formId, { first_name: 'Jane' })).to.be.rejectedWith(
+      errorMessage,
+    );
+  });
+
+  it('ignores an empty attachments array', async function () {
+    let capturedConfig;
+
+    axiosStub = sinon.stub(axios, 'create').returns(function (config) {
+      capturedConfig = config;
+      return Promise.resolve({ data: null });
+    });
+
+    const service = formService();
+    const response = await service.submitForm(formId, { first_name: 'Jane' }, []);
+    expect(response).to.be.null;
+    expect(capturedConfig).to.not.have.nested.property('data.attachments');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `formService` with `getForm()` and `submitForm()` targeting the Paubox Forms API at `https://apx.paubox.com/forms` (no auth required)
- Export `formService` from `index.js` alongside the existing `emailService`
- Add 12 new tests covering success paths, input validation, and error cases (74 total, all passing)

## New methods

**`getForm(formId)`** — `GET /public/form_data/{form_id}`
Returns the full form definition (HTML, JSON schema, CSS) for a given form UUID.

**`submitForm(formId, formData, attachments?)`** — `POST /api/forms/{form_id}/submissions`
Submits a respondent's answers. Supports optional base64-encoded file attachments up to 250 MB. Resolves to `null` on success (HTTP 201 No Content).

## Usage

```javascript
const pbMail = require('paubox-node');
const service = pbMail.formService(); // no credentials needed

// Get form definition
const form = await service.getForm('550e8400-e29b-41d4-a716-446655440000');

// Submit a response
await service.submitForm(formId, { first_name: 'Jane', email: 'jane@example.com' });

// Submit with attachments
await service.submitForm(formId, { first_name: 'Jane' }, [
  { name: 'consent.pdf', content: '<base64>' }
]);
```

## Documentation updates

- `README.md` — added Paubox Forms section with usage examples
- `api.md` (new) — full method reference for all `emailService` and `formService` methods
- `CLAUDE.md` (new) — codebase architecture guide for contributors

## Test plan

- [x] `npm test` — 74/74 passing
- [x] `npm run build` — lint, format, and Babel compile all clean

https://claude.ai/code/session_01PU9hHW3AmBLgTS2Ma6hsef