### PR TITLE
docs: link Paubox Community discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,3 +644,8 @@ See [LICENSE](LICENSE)
 ## Copyright
 
 Copyright &copy; 2025, Paubox, Inc.
+## 💬 Community & support
+
+Questions, ideas, or want to share what you built? Join the **[Paubox Community](https://github.com/Paubox/community/discussions)** — the single home for discussions across every Paubox SDK and API.
+
+🔐 Found a security issue? Email **devops@paubox.com** — please don't post it publicly.


### PR DESCRIPTION
Adds a Community & support section linking the new central [Paubox Community](https://github.com/Paubox/community/discussions) hub. Part of consolidating Discussions into one product-oriented home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)