### PR TITLE
Fix/scoped-api-keys - address QA-gate findings on authenticated Forms API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 `paubox-node` is the official Node.js SDK for the Paubox platform. It exposes two services:
 
 - **emailService** — authenticated REST client for the Paubox Email API (`api.paubox.net/v1/`). Sends messages, tracks delivery, and manages dynamic Handlebars templates.
-- **formService** — REST client for the Paubox Forms API (`next.paubox.com`). Fetches form definitions and submits form responses without credentials, and also supports authenticated form-management endpoints (list/create/update/archive/copy forms, stats, submissions, CSV/PDF exports) via an optional scoped API key.
+- **formService** — REST client for the Paubox Forms API (`apx.paubox.com/forms`). Fetches form definitions and submits form responses without credentials, and also supports authenticated form-management endpoints (list/create/update/archive/copy forms, stats, submissions, CSV/PDF exports) via an optional scoped API key.
 
 ## Repository layout
 

--- a/README.md
+++ b/README.md
@@ -647,17 +647,37 @@ const service = pbMail.formService(); // reads FORMS_API_KEY from the environmen
 
 Calling an authenticated method without an API key throws an error. The public `getForm` and `submitForm` methods work with or without a key.
 
-List forms, with optional filtering, ordering, and pagination:
+The service targets production (`https://apx.paubox.com/forms`) by default. To point it at another environment, pass `{ baseURL }` or set the `FORMS_BASE_URL` environment variable (config wins over the env var):
+
+```javascript
+const service = pbMail.formService({
+  apiKey: 'your-scoped-api-key',
+  baseURL: 'https://apx.staging.paubox.com/forms',
+});
+```
+
+> **Do not log the whole error object.** A failed authenticated request produces an error whose request config would otherwise carry your `Authorization` header and request body. This SDK strips the `Authorization` header off propagated errors, but you should still log only the fields you need — `error.message`, `error.response && error.response.status`, and `error.response && error.response.data` — rather than serializing the entire error, so credentials and payloads never reach your logs or error tracker. The examples below follow that pattern.
+
+List forms, with filtering, ordering, and pagination (`customer_id` is required — the server returns 403 without it):
 
 ```javascript
 service
-  .listForms({ search: 'intake', order_by: 'updated_at', order: 'desc', page: 1, items: 25 })
+  .listForms({
+    customer_id: 123,
+    search: 'intake',
+    order_by: 'updated_at',
+    order: 'desc',
+    page: 1,
+    items: 25,
+  })
   .then((response) => {
     console.log('Forms: ' + JSON.stringify(response.results));
     console.log('Page info: ' + JSON.stringify(response.page_info));
   })
   .catch((error) => {
-    console.log('Error listing forms: ' + JSON.stringify(error));
+    console.log('Error listing forms: ' + error.message);
+    if (error.response)
+      console.log('Status ' + error.response.status + ': ' + JSON.stringify(error.response.data));
   });
 ```
 
@@ -672,7 +692,9 @@ service
     console.log('Form: ' + JSON.stringify(form));
   })
   .catch((error) => {
-    console.log('Error getting form: ' + JSON.stringify(error));
+    console.log('Error getting form: ' + error.message);
+    if (error.response)
+      console.log('Status ' + error.response.status + ': ' + JSON.stringify(error.response.data));
   });
 ```
 
@@ -693,7 +715,9 @@ service
     console.log('New form id: ' + response.id);
   })
   .catch((error) => {
-    console.log('Error creating form: ' + JSON.stringify(error));
+    console.log('Error creating form: ' + error.message);
+    if (error.response)
+      console.log('Status ' + error.response.status + ': ' + JSON.stringify(error.response.data));
   });
 ```
 
@@ -708,7 +732,9 @@ service
     console.log('Update Form Response: ' + JSON.stringify(response));
   })
   .catch((error) => {
-    console.log('Error updating form: ' + JSON.stringify(error));
+    console.log('Error updating form: ' + error.message);
+    if (error.response)
+      console.log('Status ' + error.response.status + ': ' + JSON.stringify(error.response.data));
   });
 ```
 
@@ -733,7 +759,9 @@ service
     console.log('New form: ' + JSON.stringify(newForm));
   })
   .catch((error) => {
-    console.log('Error copying form: ' + JSON.stringify(error));
+    console.log('Error copying form: ' + error.message);
+    if (error.response)
+      console.log('Status ' + error.response.status + ': ' + JSON.stringify(error.response.data));
   });
 ```
 
@@ -757,7 +785,9 @@ service
     console.log('Total: ' + response.total);
   })
   .catch((error) => {
-    console.log('Error listing submissions: ' + JSON.stringify(error));
+    console.log('Error listing submissions: ' + error.message);
+    if (error.response)
+      console.log('Status ' + error.response.status + ': ' + JSON.stringify(error.response.data));
   });
 ```
 

--- a/api.md
+++ b/api.md
@@ -232,17 +232,17 @@ Each attachment object:
 
 ### listForms(params)
 
-List the customer's forms with optional filtering, ordering, and pagination. Requires a scoped API key with the `forms` scope.
+List the customer's forms with filtering, ordering, and pagination. Requires a scoped API key with the `forms` scope.
 
-| Parameter | Type      | Description                                                         |
-| --------- | --------- | ------------------------------------------------------------------- |
-| `params`  | `object?` | Optional query parameters; only provided keys are sent (see below). |
+| Parameter | Type     | Description                                                           |
+| --------- | -------- | --------------------------------------------------------------------- |
+| `params`  | `object` | Query parameters. `customer_id` is required; other keys are optional. |
 
 Supported `params` keys:
 
 | Key           | Type      | Description                                                                        |
 | ------------- | --------- | ---------------------------------------------------------------------------------- |
-| `customer_id` | `number`  | Filter by customer ID.                                                             |
+| `customer_id` | `number`  | **Required.** The server authorizes on this and returns 403 when it is absent.     |
 | `form_id`     | `string`  | Filter by form UUID.                                                               |
 | `search`      | `string`  | Search term.                                                                       |
 | `order`       | `string`  | `'asc'` or `'desc'` (server default: `desc`).                                      |
@@ -290,7 +290,7 @@ Supported `formAttributes` keys:
 | `recipient`                    | `string`  | No       | Recipient of form submissions.               |
 | `signable`                     | `boolean` | No       | Whether the form includes a signature field. |
 | `signature_confirmation_label` | `string`  | No       | Label for signature confirmation.            |
-| `subscription_list_id`         | `number`  | No       | Associated subscription list ID.             |
+| `subscription_list_id`         | `string`  | No       | Associated subscription list ID.             |
 | `type`                         | `string`  | No       | Form type classification.                    |
 | `active`                       | `boolean` | No       | Whether the form accepts submissions.        |
 | `submission_count`             | `number`  | No       | Initial submission count.                    |
@@ -303,14 +303,14 @@ Only provided keys are sent.
 
 ### updateForm(formId, updates)
 
-Update an existing form. PATCH semantics: only the provided keys are changed; omitted keys are left unchanged server-side. Requires a scoped API key with the `forms` scope.
+Update an existing form. Issued as an HTTP `PUT`, but with merge semantics: only the provided keys are changed; omitted keys are left unchanged server-side. Requires a scoped API key with the `forms` scope.
 
 | Parameter | Type     | Description                             |
 | --------- | -------- | --------------------------------------- |
 | `formId`  | `string` | UUID of the form to update.             |
 | `updates` | `object` | At least one updatable key (see below). |
 
-Updatable keys: `title`, `description`, `form_json`, `vanity_url`, `recipient`, `active`, `subscription_list_id`.
+Updatable keys: `title`, `description`, `form_json`, `recipient`, `active`, `subscription_list_id`.
 
 **Returns:** `Promise<object>` — `{ detail, form_id }`.
 

--- a/lib/service/formService.js
+++ b/lib/service/formService.js
@@ -6,10 +6,11 @@ class formService {
     config = Object.assign(
       {
         apiKey: process.env.FORMS_API_KEY,
+        baseURL: process.env.FORMS_BASE_URL,
       },
       config,
     );
-    this.baseURL = 'https://apx.paubox.com/forms';
+    this.baseURL = config.baseURL || 'https://apx.paubox.com/forms';
     this.apiKey = config.apiKey || null;
   }
 
@@ -24,9 +25,12 @@ class formService {
   // returns a promise that resolves to the form object
   //
   async getForm(formId) {
-    if (!formId) {
-      throw new Error('formId is required');
-    }
+    // Public route: no credential is attached, so no UUID requirement, but
+    // still encode the segment so a caller-supplied value can't splice the
+    // path.
+    const formSegment = this._pathSegment('formId', formId, {
+      requireUuid: false,
+    });
     const axiosInstance = axios.create({
       baseURL: this.baseURL,
       headers: {
@@ -35,11 +39,11 @@ class formService {
     });
     const response = await axiosInstance({
       method: 'GET',
-      url: `/public/form_data/${formId}`,
+      url: `/public/form_data/${formSegment}`,
     });
     const form = response.data;
     if (!form || !form.id) {
-      throw form;
+      throw this._unexpectedResponseError(form);
     }
     return form;
   }
@@ -60,9 +64,12 @@ class formService {
   // returns a promise that resolves to null on success (201 No Content)
   //
   async submitForm(formId, formData, attachments = null) {
-    if (!formId) {
-      throw new Error('formId is required');
-    }
+    // Public route: no credential is attached, so no UUID requirement, but
+    // still encode the segment so a caller-supplied value can't splice the
+    // path.
+    const formSegment = this._pathSegment('formId', formId, {
+      requireUuid: false,
+    });
     if (!formData || typeof formData !== 'object' || Array.isArray(formData)) {
       throw new Error('formData is required and must be an object');
     }
@@ -82,7 +89,7 @@ class formService {
     });
     await axiosInstance({
       method: 'POST',
-      url: `/api/forms/${formId}/submissions`,
+      url: `/api/forms/${formSegment}/submissions`,
       data: requestBody,
     });
     return null;
@@ -99,12 +106,51 @@ class formService {
     }
   }
 
+  // Validate a caller-supplied value before interpolating it into a URL
+  // path. Without this an id like '../stats' or 'id?x=' would steer the
+  // credentialed request to an unintended path. requireUuid enforces the
+  // canonical UUID shape (the authenticated routes take UUIDs); public
+  // routes pass requireUuid=false and are only encoded. Returns the
+  // encoded segment.
+  //
+  _pathSegment(name, value, { requireUuid = true } = {}) {
+    if (value === undefined || value === null || value === '') {
+      throw new Error(name + ' is required');
+    }
+    if (typeof value !== 'string' && typeof value !== 'number') {
+      throw new Error(name + ' must be a string');
+    }
+    const str = String(value);
+    if (requireUuid && !formService.UUID_RE.test(str)) {
+      throw new Error(name + ' must be a UUID');
+    }
+    return encodeURIComponent(str);
+  }
+
+  // Wrap an unexpected/invalid response body in a real Error without
+  // serializing the body onto an enumerable property (a logger that
+  // stringifies the error must not spill response content). The body is
+  // still reachable on the non-enumerable `body` property for debugging.
+  //
+  _unexpectedResponseError(body) {
+    const error = new Error('Unexpected response from Forms API');
+    Object.defineProperty(error, 'body', {
+      value: body,
+      enumerable: false,
+      writable: false,
+    });
+    return error;
+  }
+
   // Builds an axios instance with the Authorization header for
   // authenticated requests. extraConfig extends the base config
-  // (e.g. responseType).
+  // (e.g. responseType). A response interceptor strips the Authorization
+  // header (and the raw request header buffer) off any error before it
+  // propagates, so a caller that logs the error can't leak the bearer
+  // token to stdout / their log aggregator / their error tracker.
   //
   _authorizedAxios(extraConfig = {}) {
-    return axios.create(
+    const instance = axios.create(
       Object.assign(
         {
           baseURL: this.baseURL,
@@ -116,6 +162,16 @@ class formService {
         extraConfig,
       ),
     );
+    instance.interceptors.response.use(undefined, (error) => {
+      if (error && error.config && error.config.headers) {
+        delete error.config.headers.Authorization;
+      }
+      if (error && error.request && error.request._header) {
+        delete error.request._header;
+      }
+      return Promise.reject(error);
+    });
+    return instance;
   }
 
   // List the customer's forms with optional filtering, ordering, and
@@ -123,15 +179,26 @@ class formService {
   //
   // Requires a scoped API key with the forms scope.
   //
-  // params is an optional object; only provided keys are sent as query
-  // parameters: customer_id, form_id, search, order ('asc'|'desc'),
-  // order_by ('title'|'updated_at'|'submission_count'), archived (bool),
-  // active (bool), page, items (max 100)
+  // params must include customer_id (the server authorizes on it and
+  // returns 403 when it is absent). Other keys are optional and only sent
+  // when provided: form_id, search, order ('asc'|'desc'), order_by
+  // ('title'|'updated_at'|'submission_count'), archived (bool), active
+  // (bool), page, items (max 100)
   //
   // returns a promise that resolves to { results, page_info }
   //
   async listForms(params = {}) {
     this._requireApiKey();
+    if (!params || typeof params !== 'object' || Array.isArray(params)) {
+      throw new Error('params is required and must be an object');
+    }
+    if (
+      params.customer_id === undefined ||
+      params.customer_id === null ||
+      params.customer_id === ''
+    ) {
+      throw new Error('customer_id is required');
+    }
     const allowedParams = [
       'customer_id',
       'form_id',
@@ -156,7 +223,7 @@ class formService {
       params: queryParams,
     });
     if (!response.data || !Array.isArray(response.data.results)) {
-      throw response.data;
+      throw this._unexpectedResponseError(response.data);
     }
     return response.data;
   }
@@ -172,16 +239,14 @@ class formService {
   //
   async getFormById(formId) {
     this._requireApiKey();
-    if (!formId) {
-      throw new Error('formId is required');
-    }
+    const formSegment = this._pathSegment('formId', formId);
     const axiosInstance = this._authorizedAxios();
     const response = await axiosInstance({
       method: 'GET',
-      url: `/api/forms/${formId}`,
+      url: `/api/forms/${formSegment}`,
     });
     if (!response.data || !response.data.data || !response.data.data.id) {
-      throw response.data;
+      throw this._unexpectedResponseError(response.data);
     }
     return response.data.data;
   }
@@ -238,7 +303,7 @@ class formService {
       data: requestBody,
     });
     if (!response.data || !response.data.id) {
-      throw response.data;
+      throw this._unexpectedResponseError(response.data);
     }
     return response.data;
   }
@@ -251,15 +316,13 @@ class formService {
   // formId is the UUID of the form to update
   //
   // updates is an object with at least one of: title, description,
-  // form_json, vanity_url, recipient, active, subscription_list_id
+  // form_json, recipient, active, subscription_list_id
   //
   // returns a promise that resolves to { detail, form_id }
   //
   async updateForm(formId, updates) {
     this._requireApiKey();
-    if (!formId) {
-      throw new Error('formId is required');
-    }
+    const formSegment = this._pathSegment('formId', formId);
     if (!updates || typeof updates !== 'object' || Array.isArray(updates)) {
       throw new Error('updates is required and must be an object');
     }
@@ -267,7 +330,6 @@ class formService {
       'title',
       'description',
       'form_json',
-      'vanity_url',
       'recipient',
       'active',
       'subscription_list_id',
@@ -284,11 +346,11 @@ class formService {
     const axiosInstance = this._authorizedAxios();
     const response = await axiosInstance({
       method: 'PUT',
-      url: `/api/forms/${formId}`,
+      url: `/api/forms/${formSegment}`,
       data: requestBody,
     });
     if (!response.data || !response.data.detail) {
-      throw response.data;
+      throw this._unexpectedResponseError(response.data);
     }
     return response.data;
   }
@@ -303,16 +365,14 @@ class formService {
   //
   async archiveForm(formId) {
     this._requireApiKey();
-    if (!formId) {
-      throw new Error('formId is required');
-    }
+    const formSegment = this._pathSegment('formId', formId);
     const axiosInstance = this._authorizedAxios();
     const response = await axiosInstance({
       method: 'POST',
-      url: `/api/forms/${formId}/archive`,
+      url: `/api/forms/${formSegment}/archive`,
     });
     if (!response.data || !response.data.detail) {
-      throw response.data;
+      throw this._unexpectedResponseError(response.data);
     }
     return response.data;
   }
@@ -327,16 +387,14 @@ class formService {
   //
   async unarchiveForm(formId) {
     this._requireApiKey();
-    if (!formId) {
-      throw new Error('formId is required');
-    }
+    const formSegment = this._pathSegment('formId', formId);
     const axiosInstance = this._authorizedAxios();
     const response = await axiosInstance({
       method: 'POST',
-      url: `/api/forms/${formId}/unarchive`,
+      url: `/api/forms/${formSegment}/unarchive`,
     });
     if (!response.data || !response.data.detail) {
-      throw response.data;
+      throw this._unexpectedResponseError(response.data);
     }
     return response.data;
   }
@@ -370,7 +428,7 @@ class formService {
       },
     });
     if (!response.data || !response.data.id) {
-      throw response.data;
+      throw this._unexpectedResponseError(response.data);
     }
     return response.data;
   }
@@ -398,7 +456,7 @@ class formService {
       params: queryParams,
     });
     if (!response.data || response.data.active_form_count === undefined) {
-      throw response.data;
+      throw this._unexpectedResponseError(response.data);
     }
     return response.data;
   }
@@ -418,9 +476,7 @@ class formService {
   //
   async listSubmissions(formId, params = {}) {
     this._requireApiKey();
-    if (!formId) {
-      throw new Error('formId is required');
-    }
+    const formSegment = this._pathSegment('formId', formId);
     const allowedParams = ['submission_id', 'order_by', 'order', 'page', 'items'];
     const queryParams = {};
     for (const key of allowedParams) {
@@ -431,11 +487,11 @@ class formService {
     const axiosInstance = this._authorizedAxios();
     const response = await axiosInstance({
       method: 'GET',
-      url: `/api/forms/${formId}/submissions`,
+      url: `/api/forms/${formSegment}/submissions`,
       params: queryParams,
     });
     if (!response.data || !Array.isArray(response.data.data)) {
-      throw response.data;
+      throw this._unexpectedResponseError(response.data);
     }
     return response.data;
   }
@@ -454,12 +510,10 @@ class formService {
   //
   async exportSubmissionsCsv(formId, submissionId = null) {
     this._requireApiKey();
-    if (!formId) {
-      throw new Error('formId is required');
-    }
-    let url = `/api/forms/${formId}/submissions/submission-csv`;
-    if (submissionId) {
-      url += `/${submissionId}`;
+    const formSegment = this._pathSegment('formId', formId);
+    let url = `/api/forms/${formSegment}/submissions/submission-csv`;
+    if (submissionId !== undefined && submissionId !== null) {
+      url += `/${this._pathSegment('submissionId', submissionId)}`;
     }
     const axiosInstance = this._authorizedAxios({
       responseType: 'text',
@@ -469,7 +523,7 @@ class formService {
       url: url,
     });
     if (typeof response.data !== 'string') {
-      throw response.data;
+      throw this._unexpectedResponseError(response.data);
     }
     return response.data;
   }
@@ -486,25 +540,25 @@ class formService {
   //
   async exportSubmissionPdf(formId, submissionId) {
     this._requireApiKey();
-    if (!formId) {
-      throw new Error('formId is required');
-    }
-    if (!submissionId) {
-      throw new Error('submissionId is required');
-    }
+    const formSegment = this._pathSegment('formId', formId);
+    const submissionSegment = this._pathSegment('submissionId', submissionId);
     const axiosInstance = this._authorizedAxios({
       responseType: 'arraybuffer',
     });
     const response = await axiosInstance({
       method: 'GET',
-      url: `/api/forms/${formId}/submissions/${submissionId}/submission-pdf`,
+      url: `/api/forms/${formSegment}/submissions/${submissionSegment}/submission-pdf`,
     });
     if (response.data === null || response.data === undefined) {
-      throw response.data;
+      throw this._unexpectedResponseError(response.data);
     }
     return response.data;
   }
 }
+
+// Canonical UUID (8-4-4-4-12 hex). Used to validate id path segments before
+// they are interpolated into a credentialed request URL.
+formService.UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 module.exports = function (config) {
   return new formService(config);
 };

--- a/lib/service/formService.js
+++ b/lib/service/formService.js
@@ -144,10 +144,19 @@ class formService {
 
   // Builds an axios instance with the Authorization header for
   // authenticated requests. extraConfig extends the base config
-  // (e.g. responseType). A response interceptor strips the Authorization
-  // header (and the raw request header buffer) off any error before it
-  // propagates, so a caller that logs the error can't leak the bearer
-  // token to stdout / their log aggregator / their error tracker.
+  // (e.g. responseType).
+  //
+  // A response interceptor replaces any rejected axios error with a narrow
+  // error that carries only the caller-useful fields (message, code, and a
+  // trimmed response with status/statusText/data). The raw axios error is
+  // discarded because it keeps the outbound request — and thus the
+  // Authorization: Bearer <token> header — in several enumerable places
+  // (error.config.headers, error.request._header, error.request.headers,
+  // error.request.options.headers, error.request._redirectable._options...),
+  // and the exact set varies by transport and axios version. Reconstructing
+  // a clean error is version-independent: a caller that logs or serializes
+  // it (JSON.stringify, util.inspect, an error tracker) cannot leak the
+  // bearer token.
   //
   _authorizedAxios(extraConfig = {}) {
     const instance = axios.create(
@@ -163,15 +172,35 @@ class formService {
       ),
     );
     instance.interceptors.response.use(undefined, (error) => {
-      if (error && error.config && error.config.headers) {
-        delete error.config.headers.Authorization;
-      }
-      if (error && error.request && error.request._header) {
-        delete error.request._header;
-      }
-      return Promise.reject(error);
+      return Promise.reject(this._sanitizeRequestError(error));
     });
     return instance;
+  }
+
+  // Build a token-free error from an axios error. Copies only message,
+  // code, and a trimmed response (status/statusText/data) — never config
+  // or request, which carry the Authorization header.
+  //
+  _sanitizeRequestError(error) {
+    if (!error || typeof error !== 'object') {
+      return error;
+    }
+    const safe = new Error(error.message || 'Forms API request failed');
+    if (error.name) {
+      safe.name = error.name;
+    }
+    if (error.code !== undefined) {
+      safe.code = error.code;
+    }
+    if (error.response) {
+      safe.response = {
+        status: error.response.status,
+        statusText: error.response.statusText,
+        data: error.response.data,
+      };
+      safe.status = error.response.status;
+    }
+    return safe;
   }
 
   // List the customer's forms with optional filtering, ordering, and

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^4.2.1",
         "mocha": "^11.7.0",
+        "nock": "^13.5.6",
         "papaparse": "^5.3.0",
         "prettier": "^2.8.8",
         "sinon": "^20.0.0"
@@ -3551,6 +3552,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -3883,6 +3891,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nock": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
+      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -4127,6 +4150,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/proxy-from-env": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.2.1",
     "mocha": "^11.7.0",
+    "nock": "^13.5.6",
     "papaparse": "^5.3.0",
     "prettier": "^2.8.8",
     "sinon": "^20.0.0"

--- a/src/service/formService.js
+++ b/src/service/formService.js
@@ -4,8 +4,14 @@ const axios = require('axios');
 
 class formService {
   constructor(config = {}) {
-    config = Object.assign({ apiKey: process.env.FORMS_API_KEY }, config);
-    this.baseURL = 'https://apx.paubox.com/forms';
+    config = Object.assign(
+      {
+        apiKey: process.env.FORMS_API_KEY,
+        baseURL: process.env.FORMS_BASE_URL,
+      },
+      config,
+    );
+    this.baseURL = config.baseURL || 'https://apx.paubox.com/forms';
     this.apiKey = config.apiKey || null;
   }
 
@@ -20,9 +26,10 @@ class formService {
   // returns a promise that resolves to the form object
   //
   async getForm(formId) {
-    if (!formId) {
-      throw new Error('formId is required');
-    }
+    // Public route: no credential is attached, so no UUID requirement, but
+    // still encode the segment so a caller-supplied value can't splice the
+    // path.
+    const formSegment = this._pathSegment('formId', formId, { requireUuid: false });
 
     const axiosInstance = axios.create({
       baseURL: this.baseURL,
@@ -31,13 +38,13 @@ class formService {
 
     const response = await axiosInstance({
       method: 'GET',
-      url: `/public/form_data/${formId}`,
+      url: `/public/form_data/${formSegment}`,
     });
 
     const form = response.data;
 
     if (!form || !form.id) {
-      throw form;
+      throw this._unexpectedResponseError(form);
     }
 
     return form;
@@ -59,9 +66,10 @@ class formService {
   // returns a promise that resolves to null on success (201 No Content)
   //
   async submitForm(formId, formData, attachments = null) {
-    if (!formId) {
-      throw new Error('formId is required');
-    }
+    // Public route: no credential is attached, so no UUID requirement, but
+    // still encode the segment so a caller-supplied value can't splice the
+    // path.
+    const formSegment = this._pathSegment('formId', formId, { requireUuid: false });
     if (!formData || typeof formData !== 'object' || Array.isArray(formData)) {
       throw new Error('formData is required and must be an object');
     }
@@ -81,7 +89,7 @@ class formService {
 
     await axiosInstance({
       method: 'POST',
-      url: `/api/forms/${formId}/submissions`,
+      url: `/api/forms/${formSegment}/submissions`,
       data: requestBody,
     });
 
@@ -99,12 +107,51 @@ class formService {
     }
   }
 
+  // Validate a caller-supplied value before interpolating it into a URL
+  // path. Without this an id like '../stats' or 'id?x=' would steer the
+  // credentialed request to an unintended path. requireUuid enforces the
+  // canonical UUID shape (the authenticated routes take UUIDs); public
+  // routes pass requireUuid=false and are only encoded. Returns the
+  // encoded segment.
+  //
+  _pathSegment(name, value, { requireUuid = true } = {}) {
+    if (value === undefined || value === null || value === '') {
+      throw new Error(name + ' is required');
+    }
+    if (typeof value !== 'string' && typeof value !== 'number') {
+      throw new Error(name + ' must be a string');
+    }
+    const str = String(value);
+    if (requireUuid && !formService.UUID_RE.test(str)) {
+      throw new Error(name + ' must be a UUID');
+    }
+    return encodeURIComponent(str);
+  }
+
+  // Wrap an unexpected/invalid response body in a real Error without
+  // serializing the body onto an enumerable property (a logger that
+  // stringifies the error must not spill response content). The body is
+  // still reachable on the non-enumerable `body` property for debugging.
+  //
+  _unexpectedResponseError(body) {
+    const error = new Error('Unexpected response from Forms API');
+    Object.defineProperty(error, 'body', {
+      value: body,
+      enumerable: false,
+      writable: false,
+    });
+    return error;
+  }
+
   // Builds an axios instance with the Authorization header for
   // authenticated requests. extraConfig extends the base config
-  // (e.g. responseType).
+  // (e.g. responseType). A response interceptor strips the Authorization
+  // header (and the raw request header buffer) off any error before it
+  // propagates, so a caller that logs the error can't leak the bearer
+  // token to stdout / their log aggregator / their error tracker.
   //
   _authorizedAxios(extraConfig = {}) {
-    return axios.create(
+    const instance = axios.create(
       Object.assign(
         {
           baseURL: this.baseURL,
@@ -116,6 +163,18 @@ class formService {
         extraConfig,
       ),
     );
+
+    instance.interceptors.response.use(undefined, (error) => {
+      if (error && error.config && error.config.headers) {
+        delete error.config.headers.Authorization;
+      }
+      if (error && error.request && error.request._header) {
+        delete error.request._header;
+      }
+      return Promise.reject(error);
+    });
+
+    return instance;
   }
 
   // List the customer's forms with optional filtering, ordering, and
@@ -123,15 +182,27 @@ class formService {
   //
   // Requires a scoped API key with the forms scope.
   //
-  // params is an optional object; only provided keys are sent as query
-  // parameters: customer_id, form_id, search, order ('asc'|'desc'),
-  // order_by ('title'|'updated_at'|'submission_count'), archived (bool),
-  // active (bool), page, items (max 100)
+  // params must include customer_id (the server authorizes on it and
+  // returns 403 when it is absent). Other keys are optional and only sent
+  // when provided: form_id, search, order ('asc'|'desc'), order_by
+  // ('title'|'updated_at'|'submission_count'), archived (bool), active
+  // (bool), page, items (max 100)
   //
   // returns a promise that resolves to { results, page_info }
   //
   async listForms(params = {}) {
     this._requireApiKey();
+
+    if (!params || typeof params !== 'object' || Array.isArray(params)) {
+      throw new Error('params is required and must be an object');
+    }
+    if (
+      params.customer_id === undefined ||
+      params.customer_id === null ||
+      params.customer_id === ''
+    ) {
+      throw new Error('customer_id is required');
+    }
 
     const allowedParams = [
       'customer_id',
@@ -161,7 +232,7 @@ class formService {
     });
 
     if (!response.data || !Array.isArray(response.data.results)) {
-      throw response.data;
+      throw this._unexpectedResponseError(response.data);
     }
 
     return response.data;
@@ -179,19 +250,17 @@ class formService {
   async getFormById(formId) {
     this._requireApiKey();
 
-    if (!formId) {
-      throw new Error('formId is required');
-    }
+    const formSegment = this._pathSegment('formId', formId);
 
     const axiosInstance = this._authorizedAxios();
 
     const response = await axiosInstance({
       method: 'GET',
-      url: `/api/forms/${formId}`,
+      url: `/api/forms/${formSegment}`,
     });
 
     if (!response.data || !response.data.data || !response.data.data.id) {
-      throw response.data;
+      throw this._unexpectedResponseError(response.data);
     }
 
     return response.data.data;
@@ -256,7 +325,7 @@ class formService {
     });
 
     if (!response.data || !response.data.id) {
-      throw response.data;
+      throw this._unexpectedResponseError(response.data);
     }
 
     return response.data;
@@ -270,16 +339,14 @@ class formService {
   // formId is the UUID of the form to update
   //
   // updates is an object with at least one of: title, description,
-  // form_json, vanity_url, recipient, active, subscription_list_id
+  // form_json, recipient, active, subscription_list_id
   //
   // returns a promise that resolves to { detail, form_id }
   //
   async updateForm(formId, updates) {
     this._requireApiKey();
 
-    if (!formId) {
-      throw new Error('formId is required');
-    }
+    const formSegment = this._pathSegment('formId', formId);
     if (!updates || typeof updates !== 'object' || Array.isArray(updates)) {
       throw new Error('updates is required and must be an object');
     }
@@ -288,7 +355,6 @@ class formService {
       'title',
       'description',
       'form_json',
-      'vanity_url',
       'recipient',
       'active',
       'subscription_list_id',
@@ -309,12 +375,12 @@ class formService {
 
     const response = await axiosInstance({
       method: 'PUT',
-      url: `/api/forms/${formId}`,
+      url: `/api/forms/${formSegment}`,
       data: requestBody,
     });
 
     if (!response.data || !response.data.detail) {
-      throw response.data;
+      throw this._unexpectedResponseError(response.data);
     }
 
     return response.data;
@@ -331,19 +397,17 @@ class formService {
   async archiveForm(formId) {
     this._requireApiKey();
 
-    if (!formId) {
-      throw new Error('formId is required');
-    }
+    const formSegment = this._pathSegment('formId', formId);
 
     const axiosInstance = this._authorizedAxios();
 
     const response = await axiosInstance({
       method: 'POST',
-      url: `/api/forms/${formId}/archive`,
+      url: `/api/forms/${formSegment}/archive`,
     });
 
     if (!response.data || !response.data.detail) {
-      throw response.data;
+      throw this._unexpectedResponseError(response.data);
     }
 
     return response.data;
@@ -360,19 +424,17 @@ class formService {
   async unarchiveForm(formId) {
     this._requireApiKey();
 
-    if (!formId) {
-      throw new Error('formId is required');
-    }
+    const formSegment = this._pathSegment('formId', formId);
 
     const axiosInstance = this._authorizedAxios();
 
     const response = await axiosInstance({
       method: 'POST',
-      url: `/api/forms/${formId}/unarchive`,
+      url: `/api/forms/${formSegment}/unarchive`,
     });
 
     if (!response.data || !response.data.detail) {
-      throw response.data;
+      throw this._unexpectedResponseError(response.data);
     }
 
     return response.data;
@@ -408,7 +470,7 @@ class formService {
     });
 
     if (!response.data || !response.data.id) {
-      throw response.data;
+      throw this._unexpectedResponseError(response.data);
     }
 
     return response.data;
@@ -441,7 +503,7 @@ class formService {
     });
 
     if (!response.data || response.data.active_form_count === undefined) {
-      throw response.data;
+      throw this._unexpectedResponseError(response.data);
     }
 
     return response.data;
@@ -463,9 +525,7 @@ class formService {
   async listSubmissions(formId, params = {}) {
     this._requireApiKey();
 
-    if (!formId) {
-      throw new Error('formId is required');
-    }
+    const formSegment = this._pathSegment('formId', formId);
 
     const allowedParams = ['submission_id', 'order_by', 'order', 'page', 'items'];
 
@@ -480,12 +540,12 @@ class formService {
 
     const response = await axiosInstance({
       method: 'GET',
-      url: `/api/forms/${formId}/submissions`,
+      url: `/api/forms/${formSegment}/submissions`,
       params: queryParams,
     });
 
     if (!response.data || !Array.isArray(response.data.data)) {
-      throw response.data;
+      throw this._unexpectedResponseError(response.data);
     }
 
     return response.data;
@@ -506,13 +566,11 @@ class formService {
   async exportSubmissionsCsv(formId, submissionId = null) {
     this._requireApiKey();
 
-    if (!formId) {
-      throw new Error('formId is required');
-    }
+    const formSegment = this._pathSegment('formId', formId);
 
-    let url = `/api/forms/${formId}/submissions/submission-csv`;
-    if (submissionId) {
-      url += `/${submissionId}`;
+    let url = `/api/forms/${formSegment}/submissions/submission-csv`;
+    if (submissionId !== undefined && submissionId !== null) {
+      url += `/${this._pathSegment('submissionId', submissionId)}`;
     }
 
     const axiosInstance = this._authorizedAxios({ responseType: 'text' });
@@ -523,7 +581,7 @@ class formService {
     });
 
     if (typeof response.data !== 'string') {
-      throw response.data;
+      throw this._unexpectedResponseError(response.data);
     }
 
     return response.data;
@@ -542,27 +600,27 @@ class formService {
   async exportSubmissionPdf(formId, submissionId) {
     this._requireApiKey();
 
-    if (!formId) {
-      throw new Error('formId is required');
-    }
-    if (!submissionId) {
-      throw new Error('submissionId is required');
-    }
+    const formSegment = this._pathSegment('formId', formId);
+    const submissionSegment = this._pathSegment('submissionId', submissionId);
 
     const axiosInstance = this._authorizedAxios({ responseType: 'arraybuffer' });
 
     const response = await axiosInstance({
       method: 'GET',
-      url: `/api/forms/${formId}/submissions/${submissionId}/submission-pdf`,
+      url: `/api/forms/${formSegment}/submissions/${submissionSegment}/submission-pdf`,
     });
 
     if (response.data === null || response.data === undefined) {
-      throw response.data;
+      throw this._unexpectedResponseError(response.data);
     }
 
     return response.data;
   }
 }
+
+// Canonical UUID (8-4-4-4-12 hex). Used to validate id path segments before
+// they are interpolated into a credentialed request URL.
+formService.UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 module.exports = function (config) {
   return new formService(config);

--- a/src/service/formService.js
+++ b/src/service/formService.js
@@ -145,10 +145,19 @@ class formService {
 
   // Builds an axios instance with the Authorization header for
   // authenticated requests. extraConfig extends the base config
-  // (e.g. responseType). A response interceptor strips the Authorization
-  // header (and the raw request header buffer) off any error before it
-  // propagates, so a caller that logs the error can't leak the bearer
-  // token to stdout / their log aggregator / their error tracker.
+  // (e.g. responseType).
+  //
+  // A response interceptor replaces any rejected axios error with a narrow
+  // error that carries only the caller-useful fields (message, code, and a
+  // trimmed response with status/statusText/data). The raw axios error is
+  // discarded because it keeps the outbound request — and thus the
+  // Authorization: Bearer <token> header — in several enumerable places
+  // (error.config.headers, error.request._header, error.request.headers,
+  // error.request.options.headers, error.request._redirectable._options...),
+  // and the exact set varies by transport and axios version. Reconstructing
+  // a clean error is version-independent: a caller that logs or serializes
+  // it (JSON.stringify, util.inspect, an error tracker) cannot leak the
+  // bearer token.
   //
   _authorizedAxios(extraConfig = {}) {
     const instance = axios.create(
@@ -165,16 +174,37 @@ class formService {
     );
 
     instance.interceptors.response.use(undefined, (error) => {
-      if (error && error.config && error.config.headers) {
-        delete error.config.headers.Authorization;
-      }
-      if (error && error.request && error.request._header) {
-        delete error.request._header;
-      }
-      return Promise.reject(error);
+      return Promise.reject(this._sanitizeRequestError(error));
     });
 
     return instance;
+  }
+
+  // Build a token-free error from an axios error. Copies only message,
+  // code, and a trimmed response (status/statusText/data) — never config
+  // or request, which carry the Authorization header.
+  //
+  _sanitizeRequestError(error) {
+    if (!error || typeof error !== 'object') {
+      return error;
+    }
+
+    const safe = new Error(error.message || 'Forms API request failed');
+    if (error.name) {
+      safe.name = error.name;
+    }
+    if (error.code !== undefined) {
+      safe.code = error.code;
+    }
+    if (error.response) {
+      safe.response = {
+        status: error.response.status,
+        statusText: error.response.statusText,
+        data: error.response.data,
+      };
+      safe.status = error.response.status;
+    }
+    return safe;
   }
 
   // List the customer's forms with optional filtering, ordering, and

--- a/test/archiveForm.test.js
+++ b/test/archiveForm.test.js
@@ -70,7 +70,8 @@ describe('formService.archiveForm', function () {
 
     expect(caught, 'expected archiveForm to reject').to.not.equal(undefined);
     expect(caught.response.status).to.equal(404);
-    expect(caught.config.headers).to.not.have.property('Authorization');
+    expect(caught).to.not.have.property('config');
+    expect(caught).to.not.have.property('request');
     expect(JSON.stringify(caught)).to.not.contain(apiKey);
   });
 });

--- a/test/archiveForm.test.js
+++ b/test/archiveForm.test.js
@@ -2,108 +2,75 @@ const chai = require('chai');
 const { expect } = chai;
 const chaiAsPromised = require('chai-as-promised').default;
 
-const sinon = require('sinon');
-const axios = require('axios');
+const nock = require('nock');
 
 const formService = require('../src/service/formService.js');
 
 chai.use(chaiAsPromised);
 
-const formId = '550e8400-e29b-41d4-a716-446655440000';
 const apiKey = 'test-scoped-api-key';
+const baseURL = 'https://forms.test';
+const formId = '550e8400-e29b-41d4-a716-446655440000';
 
-const validArchiveResponse = { detail: 'Form archived.' };
+const archivedResponse = { detail: 'Form archived.' };
 
 describe('formService.archiveForm', function () {
-  let axiosStub;
-  let savedFormsApiKey;
-
-  this.beforeEach(() => {
-    savedFormsApiKey = process.env.FORMS_API_KEY;
-    delete process.env.FORMS_API_KEY;
+  beforeEach(() => {
+    nock.disableNetConnect();
   });
 
-  this.afterEach(() => {
-    if (savedFormsApiKey !== undefined) {
-      process.env.FORMS_API_KEY = savedFormsApiKey;
-    } else {
-      delete process.env.FORMS_API_KEY;
-    }
-    if (axiosStub) {
-      axiosStub.restore();
-      axiosStub = undefined;
-    }
+  afterEach(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
   });
 
   it('can archive a form', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validArchiveResponse });
-    });
+    nock(baseURL)
+      .post('/api/forms/' + formId + '/archive')
+      .reply(200, archivedResponse);
 
-    const service = formService({ apiKey });
+    const service = formService({ apiKey, baseURL });
     const response = await service.archiveForm(formId);
-    expect(response).to.deep.equal(validArchiveResponse);
+    expect(response).to.deep.equal(archivedResponse);
   });
 
   it('sends a Bearer Authorization header and POSTs to the archive endpoint', async function () {
-    let capturedConfig;
+    const scope = nock(baseURL, {
+      reqheaders: { authorization: 'Bearer ' + apiKey },
+    })
+      .post('/api/forms/' + formId + '/archive')
+      .reply(200, archivedResponse);
 
-    axiosStub = sinon.stub(axios, 'create').returns(function (config) {
-      capturedConfig = config;
-      return Promise.resolve({ data: validArchiveResponse });
-    });
-
-    const service = formService({ apiKey });
+    const service = formService({ apiKey, baseURL });
     await service.archiveForm(formId);
-
-    const createConfig = axiosStub.getCall(0).args[0];
-    expect(createConfig.headers.Authorization).to.equal('Bearer test-scoped-api-key');
-    expect(createConfig.baseURL).to.equal('https://apx.paubox.com/forms');
-
-    expect(capturedConfig.method).to.equal('POST');
-    expect(capturedConfig.url).to.equal(`/api/forms/${formId}/archive`);
-    expect(capturedConfig.data).to.be.undefined;
+    expect(scope.isDone()).to.equal(true);
   });
 
-  it('throws an error if formId is not provided', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validArchiveResponse });
-    });
-
-    const service = formService({ apiKey });
-    await expect(service.archiveForm()).to.be.rejectedWith('formId is required');
+  it('throws before any request when formId is not a UUID', async function () {
+    const service = formService({ apiKey, baseURL });
+    for (const bad of ['..', 'a?b=1', 'a#b', '', undefined]) {
+      await expect(service.archiveForm(bad)).to.be.rejectedWith(
+        /formId (is required|must be a UUID)/,
+      );
+    }
   });
 
-  it('throws an error if no apiKey was configured', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validArchiveResponse });
-    });
+  it('propagates the request error without leaking the Authorization header', async function () {
+    nock(baseURL)
+      .post('/api/forms/' + formId + '/archive')
+      .reply(404, { detail: 'Not found' });
 
-    const service = formService();
-    await expect(service.archiveForm(formId)).to.be.rejectedWith(
-      'apiKey is required for this method. Pass { apiKey } to formService() or set the FORMS_API_KEY environment variable.',
-    );
-  });
+    const service = formService({ apiKey, baseURL });
+    let caught;
+    try {
+      await service.archiveForm(formId);
+    } catch (error) {
+      caught = error;
+    }
 
-  it('throws the response if the request fails', async function () {
-    const errorMessage = 'Request failed with status code 404';
-
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.reject({ message: errorMessage, response: { status: 404 } });
-    });
-
-    const service = formService({ apiKey });
-    await expect(service.archiveForm(formId)).to.be.rejectedWith(errorMessage);
-  });
-
-  it('throws the response if an unexpected response is returned', async function () {
-    const unexpectedResponse = { this: 'is not what we expected' };
-
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: unexpectedResponse });
-    });
-
-    const service = formService({ apiKey });
-    await expect(service.archiveForm(formId)).to.be.rejected;
+    expect(caught, 'expected archiveForm to reject').to.not.equal(undefined);
+    expect(caught.response.status).to.equal(404);
+    expect(caught.config.headers).to.not.have.property('Authorization');
+    expect(JSON.stringify(caught)).to.not.contain(apiKey);
   });
 });

--- a/test/copyForm.test.js
+++ b/test/copyForm.test.js
@@ -2,131 +2,93 @@ const chai = require('chai');
 const { expect } = chai;
 const chaiAsPromised = require('chai-as-promised').default;
 
-const sinon = require('sinon');
-const axios = require('axios');
+const nock = require('nock');
 
 const formService = require('../src/service/formService.js');
 
 chai.use(chaiAsPromised);
 
-const formId = '550e8400-e29b-41d4-a716-446655440000';
-const newTitle = 'Patient Intake Form (Copy)';
 const apiKey = 'test-scoped-api-key';
+const baseURL = 'https://forms.test';
+const formId = '550e8400-e29b-41d4-a716-446655440000';
+const title = 'Patient Intake (copy)';
 
-const copiedFormResponse = {
-  id: '7c9e6679-7425-40de-944b-e07fc1f90ae7',
-  title: newTitle,
-  description: 'Please complete before your appointment.',
-  form_json: {},
-  form_html: '<form>...</form>',
-  form_css: 'form { font-family: sans-serif; }',
+const copiedResponse = {
+  id: '660e8400-e29b-41d4-a716-446655440001',
+  title: title,
   vanity_url: null,
-  version: 1,
-  active: true,
-  customer_id: 123,
-  signable: false,
-  signature_confirmation_label: null,
   submission_count: 0,
-  type: null,
-  deleted: false,
-  archived: false,
-  created_at: '2026-08-11T10:30:00Z',
-  updated_at: '2026-08-11T10:30:00Z',
 };
 
 describe('formService.copyForm', function () {
-  let axiosStub;
+  beforeEach(() => {
+    nock.disableNetConnect();
+  });
 
-  this.afterEach(() => {
-    axiosStub.restore();
+  afterEach(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
   });
 
   it('can copy a form', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: copiedFormResponse });
-    });
+    nock(baseURL)
+      .post('/api/forms/copy', { form_id: formId, title: title })
+      .reply(200, copiedResponse);
 
-    const service = formService({ apiKey: apiKey });
-    const response = await service.copyForm(formId, newTitle);
-    expect(response).to.deep.equal(copiedFormResponse);
+    const service = formService({ apiKey, baseURL });
+    const response = await service.copyForm(formId, title);
+    expect(response).to.deep.equal(copiedResponse);
   });
 
   it('sends a Bearer Authorization header and the documented body', async function () {
-    let capturedConfig;
+    const scope = nock(baseURL, {
+      reqheaders: { authorization: 'Bearer ' + apiKey },
+    })
+      .post('/api/forms/copy', { form_id: formId, title: title })
+      .reply(200, copiedResponse);
 
-    axiosStub = sinon.stub(axios, 'create').returns(function (config) {
-      capturedConfig = config;
-      return Promise.resolve({ data: copiedFormResponse });
-    });
-
-    const service = formService({ apiKey: apiKey });
-    await service.copyForm(formId, newTitle);
-
-    const createConfig = axiosStub.firstCall.args[0];
-    expect(createConfig.headers.Authorization).to.equal('Bearer ' + apiKey);
-    expect(capturedConfig.method).to.equal('POST');
-    expect(capturedConfig.url).to.equal('/api/forms/copy');
-    expect(capturedConfig.data).to.deep.equal({ form_id: formId, title: newTitle });
+    const service = formService({ apiKey, baseURL });
+    await service.copyForm(formId, title);
+    expect(scope.isDone()).to.equal(true);
   });
 
-  it('throws an error if formId is not provided', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: copiedFormResponse });
-    });
-
-    const service = formService({ apiKey: apiKey });
-    await expect(service.copyForm(null, newTitle)).to.be.rejectedWith('formId is required');
+  it('throws before any request when formId or title is missing', async function () {
+    const service = formService({ apiKey, baseURL });
+    await expect(service.copyForm('', title)).to.be.rejectedWith('formId is required');
+    await expect(service.copyForm(undefined, title)).to.be.rejectedWith('formId is required');
+    await expect(service.copyForm(formId, '')).to.be.rejectedWith('title is required');
+    await expect(service.copyForm(formId, undefined)).to.be.rejectedWith('title is required');
   });
 
-  it('throws an error if title is not provided', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: copiedFormResponse });
-    });
+  it('propagates the request error without leaking the Authorization header', async function () {
+    nock(baseURL).post('/api/forms/copy').reply(404, { detail: 'Not found' });
 
-    const service = formService({ apiKey: apiKey });
-    await expect(service.copyForm(formId)).to.be.rejectedWith('title is required');
-  });
-
-  it('throws an error if no apiKey was configured', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: copiedFormResponse });
-    });
-
-    const savedApiKey = process.env.FORMS_API_KEY;
-    delete process.env.FORMS_API_KEY;
+    const service = formService({ apiKey, baseURL });
+    let caught;
     try {
-      const service = formService();
-      await expect(service.copyForm(formId, newTitle)).to.be.rejectedWith(
-        'apiKey is required for this method',
-      );
-    } finally {
-      if (savedApiKey !== undefined) {
-        process.env.FORMS_API_KEY = savedApiKey;
-      }
+      await service.copyForm(formId, title);
+    } catch (error) {
+      caught = error;
     }
+
+    expect(caught, 'expected copyForm to reject').to.not.equal(undefined);
+    expect(caught.response.status).to.equal(404);
+    expect(caught.config.headers).to.not.have.property('Authorization');
+    expect(JSON.stringify(caught)).to.not.contain(apiKey);
   });
 
-  it('throws the response if the form is not found', async function () {
-    const errorMessage = 'Request failed with status code 404';
+  it('throws a shapeless-safe Error if an unexpected response is returned', async function () {
+    nock(baseURL).post('/api/forms/copy').reply(200, { no: 'id' });
 
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.reject({ message: errorMessage, response: { status: 404 } });
-    });
+    const service = formService({ apiKey, baseURL });
+    let caught;
+    try {
+      await service.copyForm(formId, title);
+    } catch (error) {
+      caught = error;
+    }
 
-    const service = formService({ apiKey: apiKey });
-    await expect(service.copyForm(formId, newTitle)).to.be.rejectedWith(errorMessage);
-  });
-
-  it('throws the response if an unexpected response is returned', async function () {
-    const unexpectedResponse = { this: 'is not what we expected' };
-
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: unexpectedResponse });
-    });
-
-    const service = formService({ apiKey: apiKey });
-    await expect(service.copyForm(formId, newTitle)).to.be.rejected.then((thrown) => {
-      expect(thrown).to.deep.equal(unexpectedResponse);
-    });
+    expect(caught).to.be.an.instanceof(Error);
+    expect(caught.message).to.equal('Unexpected response from Forms API');
   });
 });

--- a/test/copyForm.test.js
+++ b/test/copyForm.test.js
@@ -73,7 +73,8 @@ describe('formService.copyForm', function () {
 
     expect(caught, 'expected copyForm to reject').to.not.equal(undefined);
     expect(caught.response.status).to.equal(404);
-    expect(caught.config.headers).to.not.have.property('Authorization');
+    expect(caught).to.not.have.property('config');
+    expect(caught).to.not.have.property('request');
     expect(JSON.stringify(caught)).to.not.contain(apiKey);
   });
 

--- a/test/createForm.test.js
+++ b/test/createForm.test.js
@@ -81,7 +81,8 @@ describe('formService.createForm', function () {
 
     expect(caught, 'expected createForm to reject').to.not.equal(undefined);
     expect(caught.response.status).to.equal(403);
-    expect(caught.config.headers).to.not.have.property('Authorization');
+    expect(caught).to.not.have.property('config');
+    expect(caught).to.not.have.property('request');
     expect(JSON.stringify(caught)).to.not.contain(apiKey);
   });
 

--- a/test/createForm.test.js
+++ b/test/createForm.test.js
@@ -2,171 +2,101 @@ const chai = require('chai');
 const { expect } = chai;
 const chaiAsPromised = require('chai-as-promised').default;
 
-const sinon = require('sinon');
-const axios = require('axios');
+const nock = require('nock');
 
 const formService = require('../src/service/formService.js');
 
 chai.use(chaiAsPromised);
 
 const apiKey = 'test-scoped-api-key';
-const newFormId = '770e8400-e29b-41d4-a716-446655440002';
+const baseURL = 'https://forms.test';
 
-const validFormAttributes = {
-  title: 'Patient Intake Form',
+const validAttributes = {
+  title: 'Patient Intake',
   form_json: { fields: [{ label: 'First Name', type: 'text' }] },
-  customer_id: 123,
+  customer_id: 629,
   version: 1,
 };
 
-describe('formService.createForm', function () {
-  let axiosStub;
+const createdResponse = { id: '550e8400-e29b-41d4-a716-446655440000' };
 
-  this.afterEach(() => {
-    axiosStub.restore();
+describe('formService.createForm', function () {
+  beforeEach(() => {
+    nock.disableNetConnect();
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
   });
 
   it('can create a form', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: { id: newFormId } });
-    });
+    nock(baseURL).post('/api/forms', validAttributes).reply(200, createdResponse);
 
-    const service = formService({ apiKey: apiKey });
-    const response = await service.createForm(validFormAttributes);
-    expect(response).to.deep.equal({ id: newFormId });
+    const service = formService({ apiKey, baseURL });
+    const response = await service.createForm(validAttributes);
+    expect(response).to.deep.equal(createdResponse);
   });
 
-  it('sends an Authorization header and posts to the right url', async function () {
-    let capturedConfig;
+  it('sends a Bearer Authorization header and only the allow-listed fields', async function () {
+    const scope = nock(baseURL, {
+      reqheaders: { authorization: 'Bearer ' + apiKey },
+    })
+      .post('/api/forms', validAttributes)
+      .reply(200, createdResponse);
 
-    axiosStub = sinon.stub(axios, 'create').returns(function (config) {
-      capturedConfig = config;
-      return Promise.resolve({ data: { id: newFormId } });
-    });
-
-    const service = formService({ apiKey: apiKey });
-    await service.createForm(validFormAttributes);
-
-    const createConfig = axiosStub.firstCall.args[0];
-    expect(createConfig.headers.Authorization).to.equal('Bearer ' + apiKey);
-    expect(capturedConfig.method).to.equal('POST');
-    expect(capturedConfig.url).to.equal('/api/forms');
+    const service = formService({ apiKey, baseURL });
+    await service.createForm(Object.assign({ not_allowed: 'drop me' }, validAttributes));
+    expect(scope.isDone()).to.equal(true);
   });
 
-  it('sends only the provided fields', async function () {
-    let capturedConfig;
-
-    axiosStub = sinon.stub(axios, 'create').returns(function (config) {
-      capturedConfig = config;
-      return Promise.resolve({ data: { id: newFormId } });
-    });
-
-    const service = formService({ apiKey: apiKey });
-    await service.createForm({
-      ...validFormAttributes,
-      description: 'Please complete before your appointment.',
-      active: true,
-      not_an_allowed_field: 'should not be sent',
-    });
-
-    expect(capturedConfig.data).to.deep.equal({
-      title: validFormAttributes.title,
-      form_json: validFormAttributes.form_json,
-      customer_id: validFormAttributes.customer_id,
-      version: validFormAttributes.version,
-      description: 'Please complete before your appointment.',
-      active: true,
-    });
-  });
-
-  it('throws an error if formAttributes is not provided', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: { id: newFormId } });
-    });
-
-    const service = formService({ apiKey: apiKey });
-    await expect(service.createForm()).to.be.rejectedWith(
-      'formAttributes is required and must be an object',
-    );
-  });
-
-  it('throws an error if formAttributes is not an object', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: { id: newFormId } });
-    });
-
-    const service = formService({ apiKey: apiKey });
-    await expect(service.createForm('not an object')).to.be.rejectedWith(
-      'formAttributes is required and must be an object',
-    );
-  });
-
-  it('throws an error if formAttributes is an array', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: { id: newFormId } });
-    });
-
-    const service = formService({ apiKey: apiKey });
-    await expect(service.createForm(['title'])).to.be.rejectedWith(
-      'formAttributes is required and must be an object',
-    );
-  });
-
-  ['title', 'form_json', 'customer_id', 'version'].forEach((field) => {
-    it(`throws an error if ${field} is missing`, async function () {
-      axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-        return Promise.resolve({ data: { id: newFormId } });
-      });
-
-      const attributes = { ...validFormAttributes };
-      delete attributes[field];
-
-      const service = formService({ apiKey: apiKey });
-      await expect(service.createForm(attributes)).to.be.rejectedWith(`${field} is required`);
-    });
-  });
-
-  it('throws an error if no apiKey was configured', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: { id: newFormId } });
-    });
-
-    const savedEnvKey = process.env.FORMS_API_KEY;
-    delete process.env.FORMS_API_KEY;
-
-    try {
-      const service = formService();
-      await expect(service.createForm(validFormAttributes)).to.be.rejectedWith(
-        'apiKey is required for this method. Pass { apiKey } to formService() or set the FORMS_API_KEY environment variable.',
-      );
-    } finally {
-      if (savedEnvKey !== undefined) {
-        process.env.FORMS_API_KEY = savedEnvKey;
-      }
+  it('throws before any request when a required field is missing', async function () {
+    const service = formService({ apiKey, baseURL });
+    for (const field of ['title', 'form_json', 'customer_id', 'version']) {
+      const attrs = Object.assign({}, validAttributes);
+      delete attrs[field];
+      await expect(service.createForm(attrs)).to.be.rejectedWith(field + ' is required');
     }
   });
 
-  it('throws the response if the request fails', async function () {
-    const errorMessage = 'Request failed with status code 422';
-
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.reject({ message: errorMessage, response: { status: 422 } });
-    });
-
-    const service = formService({ apiKey: apiKey });
-    await expect(service.createForm(validFormAttributes)).to.be.rejectedWith(errorMessage);
+  it('throws before any request when formAttributes is not an object', async function () {
+    const service = formService({ apiKey, baseURL });
+    for (const bad of [null, 'a string', [1, 2], undefined]) {
+      await expect(service.createForm(bad)).to.be.rejectedWith(
+        'formAttributes is required and must be an object',
+      );
+    }
   });
 
-  it('throws the response if an unexpected response is returned', async function () {
-    const unexpectedResponse = { this: 'is not what we expected' };
+  it('propagates the request error without leaking the Authorization header', async function () {
+    nock(baseURL).post('/api/forms').reply(403, { detail: 'Forbidden' });
 
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: unexpectedResponse });
-    });
+    const service = formService({ apiKey, baseURL });
+    let caught;
+    try {
+      await service.createForm(validAttributes);
+    } catch (error) {
+      caught = error;
+    }
 
-    const service = formService({ apiKey: apiKey });
-    await expect(service.createForm(validFormAttributes)).to.be.rejected.and.eventually.deep.equal(
-      unexpectedResponse,
-    );
+    expect(caught, 'expected createForm to reject').to.not.equal(undefined);
+    expect(caught.response.status).to.equal(403);
+    expect(caught.config.headers).to.not.have.property('Authorization');
+    expect(JSON.stringify(caught)).to.not.contain(apiKey);
+  });
+
+  it('throws a shapeless-safe Error if an unexpected response is returned', async function () {
+    nock(baseURL).post('/api/forms').reply(200, { no: 'id' });
+
+    const service = formService({ apiKey, baseURL });
+    let caught;
+    try {
+      await service.createForm(validAttributes);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).to.be.an.instanceof(Error);
+    expect(caught.message).to.equal('Unexpected response from Forms API');
   });
 });

--- a/test/exportSubmissionPdf.test.js
+++ b/test/exportSubmissionPdf.test.js
@@ -77,7 +77,8 @@ describe('formService.exportSubmissionPdf', function () {
 
     expect(caught, 'expected exportSubmissionPdf to reject').to.not.equal(undefined);
     expect(caught.response.status).to.equal(404);
-    expect(caught.config.headers).to.not.have.property('Authorization');
+    expect(caught).to.not.have.property('config');
+    expect(caught).to.not.have.property('request');
     expect(JSON.stringify(caught)).to.not.contain(apiKey);
   });
 });

--- a/test/exportSubmissionPdf.test.js
+++ b/test/exportSubmissionPdf.test.js
@@ -2,116 +2,82 @@ const chai = require('chai');
 const { expect } = chai;
 const chaiAsPromised = require('chai-as-promised').default;
 
-const sinon = require('sinon');
-const axios = require('axios');
+const nock = require('nock');
 
 const formService = require('../src/service/formService.js');
 
 chai.use(chaiAsPromised);
 
 const apiKey = 'test-scoped-api-key';
+const baseURL = 'https://forms.test';
 const formId = '550e8400-e29b-41d4-a716-446655440000';
-const submissionId = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d';
+const submissionId = 'b3b8c7e2-1d2f-4c5a-9e8d-7f6a5b4c3d2e';
 
-const validPdfResponse = Buffer.from('%PDF-1.4 fake pdf content');
+// Minimal PDF byte stream (starts with the %PDF magic number).
+const pdfBytes = Buffer.from('%PDF-1.4\n%\xFF\xFF\xFF\xFF\n', 'binary');
 
 describe('formService.exportSubmissionPdf', function () {
-  let axiosStub;
+  beforeEach(() => {
+    nock.disableNetConnect();
+  });
 
-  this.afterEach(() => {
-    axiosStub.restore();
+  afterEach(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
   });
 
   it('can export a submission as a PDF', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validPdfResponse });
-    });
+    nock(baseURL)
+      .get('/api/forms/' + formId + '/submissions/' + submissionId + '/submission-pdf')
+      .reply(200, pdfBytes, { 'Content-Type': 'application/pdf' });
 
-    const service = formService({ apiKey: apiKey });
+    const service = formService({ apiKey, baseURL });
     const response = await service.exportSubmissionPdf(formId, submissionId);
-    expect(response).to.equal(validPdfResponse);
+    const buf = Buffer.from(response);
+    expect(buf.slice(0, 4).toString('ascii')).to.equal('%PDF');
   });
 
-  it('sends the Authorization header, arraybuffer responseType, and the submission url', async function () {
-    let capturedConfig;
+  it('sends the Bearer Authorization header, arraybuffer responseType, and the submission url', async function () {
+    const scope = nock(baseURL, {
+      reqheaders: { authorization: 'Bearer ' + apiKey },
+    })
+      .get('/api/forms/' + formId + '/submissions/' + submissionId + '/submission-pdf')
+      .reply(200, pdfBytes, { 'Content-Type': 'application/pdf' });
 
-    axiosStub = sinon.stub(axios, 'create').returns(function (config) {
-      capturedConfig = config;
-      return Promise.resolve({ data: validPdfResponse });
-    });
-
-    const service = formService({ apiKey: apiKey });
+    const service = formService({ apiKey, baseURL });
     await service.exportSubmissionPdf(formId, submissionId);
+    expect(scope.isDone()).to.equal(true);
+  });
 
-    const createConfig = axiosStub.getCall(0).args[0];
-    expect(createConfig.headers.Authorization).to.equal('Bearer test-scoped-api-key');
-    expect(createConfig.responseType).to.equal('arraybuffer');
-    expect(capturedConfig.url).to.equal(
-      `/api/forms/${formId}/submissions/${submissionId}/submission-pdf`,
+  it('throws before any request when an id is not a UUID', async function () {
+    const service = formService({ apiKey, baseURL });
+    await expect(service.exportSubmissionPdf('..', submissionId)).to.be.rejectedWith(
+      /formId must be a UUID/,
+    );
+    await expect(service.exportSubmissionPdf(formId, '..')).to.be.rejectedWith(
+      /submissionId must be a UUID/,
+    );
+    await expect(service.exportSubmissionPdf(formId, undefined)).to.be.rejectedWith(
+      /submissionId is required/,
     );
   });
 
-  it('throws an error if formId is not provided', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validPdfResponse });
-    });
+  it('propagates the request error without leaking the Authorization header', async function () {
+    nock(baseURL)
+      .get('/api/forms/' + formId + '/submissions/' + submissionId + '/submission-pdf')
+      .reply(404, 'Not found', { 'Content-Type': 'text/plain' });
 
-    const service = formService({ apiKey: apiKey });
-    await expect(service.exportSubmissionPdf(null, submissionId)).to.be.rejectedWith(
-      'formId is required',
-    );
-  });
-
-  it('throws an error if submissionId is not provided', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validPdfResponse });
-    });
-
-    const service = formService({ apiKey: apiKey });
-    await expect(service.exportSubmissionPdf(formId)).to.be.rejectedWith(
-      'submissionId is required',
-    );
-  });
-
-  it('throws an error if no apiKey was configured', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validPdfResponse });
-    });
-
-    const savedEnvKey = process.env.FORMS_API_KEY;
-    delete process.env.FORMS_API_KEY;
-
+    const service = formService({ apiKey, baseURL });
+    let caught;
     try {
-      const service = formService();
-      await expect(service.exportSubmissionPdf(formId, submissionId)).to.be.rejectedWith(
-        'apiKey is required for this method',
-      );
-    } finally {
-      if (savedEnvKey !== undefined) {
-        process.env.FORMS_API_KEY = savedEnvKey;
-      }
+      await service.exportSubmissionPdf(formId, submissionId);
+    } catch (error) {
+      caught = error;
     }
-  });
 
-  it('throws the response if the request fails', async function () {
-    const errorMessage = 'Request failed with status code 404';
-
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.reject({ message: errorMessage, response: { status: 404 } });
-    });
-
-    const service = formService({ apiKey: apiKey });
-    await expect(service.exportSubmissionPdf(formId, submissionId)).to.be.rejectedWith(
-      errorMessage,
-    );
-  });
-
-  it('throws if the response body is null', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: null });
-    });
-
-    const service = formService({ apiKey: apiKey });
-    await expect(service.exportSubmissionPdf(formId, submissionId)).to.be.rejected;
+    expect(caught, 'expected exportSubmissionPdf to reject').to.not.equal(undefined);
+    expect(caught.response.status).to.equal(404);
+    expect(caught.config.headers).to.not.have.property('Authorization');
+    expect(JSON.stringify(caught)).to.not.contain(apiKey);
   });
 });

--- a/test/exportSubmissionsCsv.test.js
+++ b/test/exportSubmissionsCsv.test.js
@@ -81,7 +81,8 @@ describe('formService.exportSubmissionsCsv', function () {
 
     expect(caught, 'expected exportSubmissionsCsv to reject').to.not.equal(undefined);
     expect(caught.response.status).to.equal(404);
-    expect(caught.config.headers).to.not.have.property('Authorization');
+    expect(caught).to.not.have.property('config');
+    expect(caught).to.not.have.property('request');
     expect(JSON.stringify(caught)).to.not.contain(apiKey);
   });
 });

--- a/test/exportSubmissionsCsv.test.js
+++ b/test/exportSubmissionsCsv.test.js
@@ -2,116 +2,86 @@ const chai = require('chai');
 const { expect } = chai;
 const chaiAsPromised = require('chai-as-promised').default;
 
-const sinon = require('sinon');
-const axios = require('axios');
+const nock = require('nock');
 
 const formService = require('../src/service/formService.js');
 
 chai.use(chaiAsPromised);
 
 const apiKey = 'test-scoped-api-key';
+const baseURL = 'https://forms.test';
 const formId = '550e8400-e29b-41d4-a716-446655440000';
-const submissionId = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d';
+const submissionId = 'b3b8c7e2-1d2f-4c5a-9e8d-7f6a5b4c3d2e';
 
-const validCsvResponse = 'Created At,First Name,Last Name\n2024-06-01T08:00:00Z,Jane,Smith\n';
+const csvBody = 'Created At,First Name\n2026-08-11,Jane\n';
 
 describe('formService.exportSubmissionsCsv', function () {
-  let axiosStub;
+  beforeEach(() => {
+    nock.disableNetConnect();
+  });
 
-  this.afterEach(() => {
-    axiosStub.restore();
+  afterEach(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
   });
 
   it('can export all submissions as CSV', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validCsvResponse });
-    });
+    nock(baseURL)
+      .get('/api/forms/' + formId + '/submissions/submission-csv')
+      .reply(200, csvBody, { 'Content-Type': 'text/csv' });
 
-    const service = formService({ apiKey: apiKey });
+    const service = formService({ apiKey, baseURL });
     const response = await service.exportSubmissionsCsv(formId);
-    expect(response).to.equal(validCsvResponse);
+    expect(response).to.be.a('string');
+    expect(response).to.equal(csvBody);
   });
 
-  it('sends the Authorization header, text responseType, and the collection url', async function () {
-    let capturedConfig;
+  it('sends the Bearer Authorization header and text responseType to the collection url', async function () {
+    const scope = nock(baseURL, {
+      reqheaders: { authorization: 'Bearer ' + apiKey },
+    })
+      .get('/api/forms/' + formId + '/submissions/submission-csv')
+      .reply(200, csvBody, { 'Content-Type': 'text/csv' });
 
-    axiosStub = sinon.stub(axios, 'create').returns(function (config) {
-      capturedConfig = config;
-      return Promise.resolve({ data: validCsvResponse });
-    });
-
-    const service = formService({ apiKey: apiKey });
+    const service = formService({ apiKey, baseURL });
     await service.exportSubmissionsCsv(formId);
-
-    const createConfig = axiosStub.getCall(0).args[0];
-    expect(createConfig.headers.Authorization).to.equal('Bearer test-scoped-api-key');
-    expect(createConfig.responseType).to.equal('text');
-    expect(capturedConfig.url).to.equal(`/api/forms/${formId}/submissions/submission-csv`);
+    expect(scope.isDone()).to.equal(true);
   });
 
   it('appends the submissionId to the url when provided', async function () {
-    let capturedConfig;
+    const scope = nock(baseURL)
+      .get('/api/forms/' + formId + '/submissions/submission-csv/' + submissionId)
+      .reply(200, csvBody, { 'Content-Type': 'text/csv' });
 
-    axiosStub = sinon.stub(axios, 'create').returns(function (config) {
-      capturedConfig = config;
-      return Promise.resolve({ data: validCsvResponse });
-    });
-
-    const service = formService({ apiKey: apiKey });
+    const service = formService({ apiKey, baseURL });
     await service.exportSubmissionsCsv(formId, submissionId);
-    expect(capturedConfig.url).to.equal(
-      `/api/forms/${formId}/submissions/submission-csv/${submissionId}`,
+    expect(scope.isDone()).to.equal(true);
+  });
+
+  it('throws before any request when an id is not a UUID', async function () {
+    const service = formService({ apiKey, baseURL });
+    await expect(service.exportSubmissionsCsv('..')).to.be.rejectedWith(/formId must be a UUID/);
+    await expect(service.exportSubmissionsCsv(formId, '../secret')).to.be.rejectedWith(
+      /submissionId must be a UUID/,
     );
   });
 
-  it('throws an error if formId is not provided', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validCsvResponse });
-    });
+  it('propagates the request error without leaking the Authorization header', async function () {
+    nock(baseURL)
+      .get('/api/forms/' + formId + '/submissions/submission-csv')
+      .reply(404, 'Not found', { 'Content-Type': 'text/plain' });
 
-    const service = formService({ apiKey: apiKey });
-    await expect(service.exportSubmissionsCsv()).to.be.rejectedWith('formId is required');
-  });
-
-  it('throws an error if no apiKey was configured', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validCsvResponse });
-    });
-
-    const savedEnvKey = process.env.FORMS_API_KEY;
-    delete process.env.FORMS_API_KEY;
-
+    const service = formService({ apiKey, baseURL });
+    let caught;
     try {
-      const service = formService();
-      await expect(service.exportSubmissionsCsv(formId)).to.be.rejectedWith(
-        'apiKey is required for this method',
-      );
-    } finally {
-      if (savedEnvKey !== undefined) {
-        process.env.FORMS_API_KEY = savedEnvKey;
-      }
+      await service.exportSubmissionsCsv(formId);
+    } catch (error) {
+      caught = error;
     }
-  });
 
-  it('throws the response if the request fails', async function () {
-    const errorMessage = 'Request failed with status code 404';
-
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.reject({ message: errorMessage, response: { status: 404 } });
-    });
-
-    const service = formService({ apiKey: apiKey });
-    await expect(service.exportSubmissionsCsv(formId)).to.be.rejectedWith(errorMessage);
-  });
-
-  it('throws the response if a non-string response is returned', async function () {
-    const unexpectedResponse = { this: 'is not what we expected' };
-
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: unexpectedResponse });
-    });
-
-    const service = formService({ apiKey: apiKey });
-    await expect(service.exportSubmissionsCsv(formId)).to.be.rejected;
+    expect(caught, 'expected exportSubmissionsCsv to reject').to.not.equal(undefined);
+    expect(caught.response.status).to.equal(404);
+    expect(caught.config.headers).to.not.have.property('Authorization');
+    expect(JSON.stringify(caught)).to.not.contain(apiKey);
   });
 });

--- a/test/formServiceSecurity.test.js
+++ b/test/formServiceSecurity.test.js
@@ -3,6 +3,7 @@ const { expect } = chai;
 const chaiAsPromised = require('chai-as-promised').default;
 
 const nock = require('nock');
+const util = require('util');
 
 const formService = require('../src/service/formService.js');
 
@@ -131,10 +132,15 @@ describe('formService security hardening', function () {
         caught = error;
       }
       expect(caught, 'expected the call to reject').to.not.equal(undefined);
-      if (caught.config && caught.config.headers) {
-        expect(caught.config.headers).to.not.have.property('Authorization');
-      }
+      // The propagated error carries no request/config branch at all — those
+      // are where axios (and follow-redirects) keep the Authorization header.
+      expect(caught).to.not.have.property('config');
+      expect(caught).to.not.have.property('request');
+      // And the token appears via no serialization or deep-inspection path.
       expect(JSON.stringify(caught)).to.not.contain(apiKey);
+      expect(util.inspect(caught, { depth: null })).to.not.contain(apiKey);
+      // Caller-useful fields survive the sanitization.
+      expect(caught.response.status).to.equal(500);
     }
   });
 });

--- a/test/formServiceSecurity.test.js
+++ b/test/formServiceSecurity.test.js
@@ -1,0 +1,184 @@
+const chai = require('chai');
+const { expect } = chai;
+const chaiAsPromised = require('chai-as-promised').default;
+
+const nock = require('nock');
+
+const formService = require('../src/service/formService.js');
+
+chai.use(chaiAsPromised);
+
+const apiKey = 'test-scoped-api-key';
+const baseURL = 'https://forms.test';
+const formId = '550e8400-e29b-41d4-a716-446655440000';
+const submissionId = 'b3b8c7e2-1d2f-4c5a-9e8d-7f6a5b4c3d2e';
+
+// The authenticated methods that interpolate a caller-supplied id into the
+// request path. Each entry invokes the method with a hostile formId.
+const idPathMethods = [
+  (s, id) => s.getFormById(id),
+  (s, id) => s.updateForm(id, { title: 'x' }),
+  (s, id) => s.archiveForm(id),
+  (s, id) => s.unarchiveForm(id),
+  (s, id) => s.listSubmissions(id),
+  (s, id) => s.exportSubmissionsCsv(id),
+  (s, id) => s.exportSubmissionPdf(id, submissionId),
+];
+
+const hostileIds = [
+  '..',
+  '../..',
+  '..%2F..%2Fadmin',
+  formId + '/archive',
+  'a?x=1',
+  'a#frag',
+  'a b',
+];
+
+describe('formService security hardening', function () {
+  beforeEach(() => {
+    nock.disableNetConnect();
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
+  });
+
+  it('never issues a request when the id path segment is hostile (no retarget with the bearer)', async function () {
+    // disableNetConnect is active and no interceptor is registered, so any
+    // request that escaped validation would reject with a net-connect error
+    // (a different message) rather than the UUID validation error asserted
+    // here. This proves the credentialed request is not retargeted.
+    const service = formService({ apiKey, baseURL });
+    for (const invoke of idPathMethods) {
+      for (const bad of hostileIds) {
+        await expect(invoke(service, bad)).to.be.rejectedWith(/must be a UUID/);
+      }
+    }
+  });
+
+  it('strips the Authorization header from a propagated error on every authenticated method', async function () {
+    const service = formService({ apiKey, baseURL });
+
+    const calls = [
+      () => {
+        nock(baseURL).get('/api/forms').query(true).reply(500, { detail: 'boom' });
+        return service.listForms({ customer_id: 629 });
+      },
+      () => {
+        nock(baseURL)
+          .get('/api/forms/' + formId)
+          .reply(500, { detail: 'boom' });
+        return service.getFormById(formId);
+      },
+      () => {
+        nock(baseURL).post('/api/forms').reply(500, { detail: 'boom' });
+        return service.createForm({ title: 't', form_json: {}, customer_id: 629, version: 1 });
+      },
+      () => {
+        nock(baseURL)
+          .put('/api/forms/' + formId)
+          .reply(500, { detail: 'boom' });
+        return service.updateForm(formId, { title: 'x' });
+      },
+      () => {
+        nock(baseURL)
+          .post('/api/forms/' + formId + '/archive')
+          .reply(500, { detail: 'boom' });
+        return service.archiveForm(formId);
+      },
+      () => {
+        nock(baseURL)
+          .post('/api/forms/' + formId + '/unarchive')
+          .reply(500, { detail: 'boom' });
+        return service.unarchiveForm(formId);
+      },
+      () => {
+        nock(baseURL).post('/api/forms/copy').reply(500, { detail: 'boom' });
+        return service.copyForm(formId, 'copy');
+      },
+      () => {
+        nock(baseURL).get('/api/forms/stats').query(true).reply(500, { detail: 'boom' });
+        return service.getFormStats();
+      },
+      () => {
+        nock(baseURL)
+          .get('/api/forms/' + formId + '/submissions')
+          .query(true)
+          .reply(500, { detail: 'boom' });
+        return service.listSubmissions(formId);
+      },
+      () => {
+        nock(baseURL)
+          .get('/api/forms/' + formId + '/submissions/submission-csv')
+          .reply(500, 'boom', { 'Content-Type': 'text/plain' });
+        return service.exportSubmissionsCsv(formId);
+      },
+      () => {
+        nock(baseURL)
+          .get('/api/forms/' + formId + '/submissions/' + submissionId + '/submission-pdf')
+          .reply(500, 'boom', { 'Content-Type': 'text/plain' });
+        return service.exportSubmissionPdf(formId, submissionId);
+      },
+    ];
+
+    for (const call of calls) {
+      let caught;
+      try {
+        await call();
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught, 'expected the call to reject').to.not.equal(undefined);
+      if (caught.config && caught.config.headers) {
+        expect(caught.config.headers).to.not.have.property('Authorization');
+      }
+      expect(JSON.stringify(caught)).to.not.contain(apiKey);
+    }
+  });
+});
+
+describe('formService baseURL resolution', function () {
+  it('prefers config.baseURL over FORMS_BASE_URL and the prod default', function () {
+    const saved = process.env.FORMS_BASE_URL;
+    process.env.FORMS_BASE_URL = 'https://from-env.test';
+    try {
+      expect(formService({ apiKey, baseURL: 'https://from-config.test' }).baseURL).to.equal(
+        'https://from-config.test',
+      );
+    } finally {
+      if (saved === undefined) {
+        delete process.env.FORMS_BASE_URL;
+      } else {
+        process.env.FORMS_BASE_URL = saved;
+      }
+    }
+  });
+
+  it('falls back to FORMS_BASE_URL when no config is given', function () {
+    const saved = process.env.FORMS_BASE_URL;
+    process.env.FORMS_BASE_URL = 'https://from-env.test';
+    try {
+      expect(formService({ apiKey }).baseURL).to.equal('https://from-env.test');
+    } finally {
+      if (saved === undefined) {
+        delete process.env.FORMS_BASE_URL;
+      } else {
+        process.env.FORMS_BASE_URL = saved;
+      }
+    }
+  });
+
+  it('falls back to the production default when neither is set', function () {
+    const saved = process.env.FORMS_BASE_URL;
+    delete process.env.FORMS_BASE_URL;
+    try {
+      expect(formService({ apiKey }).baseURL).to.equal('https://apx.paubox.com/forms');
+    } finally {
+      if (saved !== undefined) {
+        process.env.FORMS_BASE_URL = saved;
+      }
+    }
+  });
+});

--- a/test/getFormById.test.js
+++ b/test/getFormById.test.js
@@ -93,7 +93,8 @@ describe('formService.getFormById', function () {
 
     expect(caught, 'expected getFormById to reject').to.not.equal(undefined);
     expect(caught.response.status).to.equal(404);
-    expect(caught.config.headers).to.not.have.property('Authorization');
+    expect(caught).to.not.have.property('config');
+    expect(caught).to.not.have.property('request');
     expect(JSON.stringify(caught)).to.not.contain(apiKey);
   });
 

--- a/test/getFormById.test.js
+++ b/test/getFormById.test.js
@@ -2,92 +2,74 @@ const chai = require('chai');
 const { expect } = chai;
 const chaiAsPromised = require('chai-as-promised').default;
 
-const sinon = require('sinon');
-const axios = require('axios');
+const nock = require('nock');
 
 const formService = require('../src/service/formService.js');
 
 chai.use(chaiAsPromised);
 
 const apiKey = 'test-scoped-api-key';
+const baseURL = 'https://forms.test';
 const formId = '550e8400-e29b-41d4-a716-446655440000';
 
 const validForm = {
   id: formId,
   title: 'Patient Intake Form',
-  description: 'Please complete before your appointment.',
-  form_json: {},
-  form_html: '<form>...</form>',
-  form_css: 'form { font-family: sans-serif; }',
-  vanity_url: null,
-  version: 1,
   active: false,
-  customer_id: 123,
-  signable: false,
-  signature_confirmation_label: null,
-  submission_count: 42,
-  type: null,
-  deleted: false,
   archived: true,
-  created_at: '2024-01-15T10:30:00Z',
-  updated_at: '2024-06-01T08:00:00Z',
 };
 
 describe('formService.getFormById', function () {
-  let axiosStub;
+  beforeEach(() => {
+    nock.disableNetConnect();
+  });
 
-  this.afterEach(() => {
-    axiosStub.restore();
+  afterEach(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
   });
 
   it('can get a form by id, including archived and inactive forms', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: { data: validForm } });
-    });
+    nock(baseURL)
+      .get('/api/forms/' + formId)
+      .reply(200, { data: validForm });
 
-    const service = formService({ apiKey: apiKey });
+    const service = formService({ apiKey, baseURL });
     const response = await service.getFormById(formId);
     expect(response).to.deep.equal(validForm);
   });
 
-  it('sends an Authorization header and requests the right url', async function () {
-    let capturedConfig;
+  it('sends a Bearer Authorization header and requests the right url', async function () {
+    const scope = nock(baseURL, {
+      reqheaders: { authorization: 'Bearer ' + apiKey },
+    })
+      .get('/api/forms/' + formId)
+      .reply(200, { data: validForm });
 
-    axiosStub = sinon.stub(axios, 'create').returns(function (config) {
-      capturedConfig = config;
-      return Promise.resolve({ data: { data: validForm } });
-    });
-
-    const service = formService({ apiKey: apiKey });
+    const service = formService({ apiKey, baseURL });
     await service.getFormById(formId);
-
-    const createConfig = axiosStub.firstCall.args[0];
-    expect(createConfig.headers.Authorization).to.equal('Bearer ' + apiKey);
-    expect(capturedConfig.method).to.equal('GET');
-    expect(capturedConfig.url).to.equal(`/api/forms/${formId}`);
+    expect(scope.isDone()).to.equal(true);
   });
 
-  it('throws an error if formId is not provided', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: { data: validForm } });
-    });
-
-    const service = formService({ apiKey: apiKey });
-    await expect(service.getFormById()).to.be.rejectedWith('formId is required');
+  it('throws before any request when formId is not a UUID', async function () {
+    const service = formService({ apiKey, baseURL });
+    for (const bad of ['..', '../..', '..%2F..%2Fadmin', 'a?b=1', 'a#b', 'a b', '', undefined]) {
+      await expect(service.getFormById(bad)).to.be.rejectedWith(
+        /formId (is required|must be a UUID)/,
+      );
+    }
+    // No nock interceptor is registered; a leaked request would surface as a
+    // net-connect error, so these assertions prove no HTTP was attempted.
   });
 
   it('throws an error if no apiKey was configured', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: { data: validForm } });
-    });
-
     const savedEnvKey = process.env.FORMS_API_KEY;
     delete process.env.FORMS_API_KEY;
 
     try {
-      const service = formService();
+      const service = formService({ baseURL });
       await expect(service.getFormById(formId)).to.be.rejectedWith(
-        'apiKey is required for this method. Pass { apiKey } to formService() or set the FORMS_API_KEY environment variable.',
+        'apiKey is required for this method.',
       );
     } finally {
       if (savedEnvKey !== undefined) {
@@ -96,40 +78,39 @@ describe('formService.getFormById', function () {
     }
   });
 
-  it('throws the response if the form is not found', async function () {
-    const errorMessage = 'Request failed with status code 404';
+  it('propagates the request error without leaking the Authorization header', async function () {
+    nock(baseURL)
+      .get('/api/forms/' + formId)
+      .reply(404, { detail: 'Not found' });
 
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.reject({ message: errorMessage, response: { status: 404 } });
-    });
+    const service = formService({ apiKey, baseURL });
+    let caught;
+    try {
+      await service.getFormById(formId);
+    } catch (error) {
+      caught = error;
+    }
 
-    const service = formService({ apiKey: apiKey });
-    await expect(service.getFormById(formId)).to.be.rejectedWith(errorMessage);
+    expect(caught, 'expected getFormById to reject').to.not.equal(undefined);
+    expect(caught.response.status).to.equal(404);
+    expect(caught.config.headers).to.not.have.property('Authorization');
+    expect(JSON.stringify(caught)).to.not.contain(apiKey);
   });
 
-  it('throws the response if an unexpected response is returned', async function () {
-    const unexpectedResponse = { this: 'is not what we expected' };
+  it('throws a shapeless-safe Error if the wrapped form has no id', async function () {
+    nock(baseURL)
+      .get('/api/forms/' + formId)
+      .reply(200, { data: { title: 'no id here' } });
 
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: unexpectedResponse });
-    });
+    const service = formService({ apiKey, baseURL });
+    let caught;
+    try {
+      await service.getFormById(formId);
+    } catch (error) {
+      caught = error;
+    }
 
-    const service = formService({ apiKey: apiKey });
-    await expect(service.getFormById(formId)).to.be.rejected.and.eventually.deep.equal(
-      unexpectedResponse,
-    );
-  });
-
-  it('throws the response if the wrapped form has no id', async function () {
-    const responseWithoutId = { data: { title: 'No id here' } };
-
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: responseWithoutId });
-    });
-
-    const service = formService({ apiKey: apiKey });
-    await expect(service.getFormById(formId)).to.be.rejected.and.eventually.deep.equal(
-      responseWithoutId,
-    );
+    expect(caught).to.be.an.instanceof(Error);
+    expect(caught.message).to.equal('Unexpected response from Forms API');
   });
 });

--- a/test/getFormStats.test.js
+++ b/test/getFormStats.test.js
@@ -2,109 +2,93 @@ const chai = require('chai');
 const { expect } = chai;
 const chaiAsPromised = require('chai-as-promised').default;
 
-const sinon = require('sinon');
-const axios = require('axios');
+const nock = require('nock');
 
 const formService = require('../src/service/formService.js');
 
 chai.use(chaiAsPromised);
 
 const apiKey = 'test-scoped-api-key';
+const baseURL = 'https://forms.test';
+const customerId = 629;
 
-const validStatsResponse = {
-  active_form_count: 12,
-  total_submission_count: 340,
-  submissions_last_7_days: 27,
+const statsResponse = {
+  active_form_count: 3,
+  total_submission_count: 128,
+  submissions_last_7_days: 12,
 };
 
 describe('formService.getFormStats', function () {
-  let axiosStub;
+  beforeEach(() => {
+    nock.disableNetConnect();
+  });
 
-  this.afterEach(() => {
-    axiosStub.restore();
+  afterEach(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
   });
 
   it('can get form stats', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validStatsResponse });
-    });
+    nock(baseURL).get('/api/forms/stats').reply(200, statsResponse);
 
-    const service = formService({ apiKey: apiKey });
+    const service = formService({ apiKey, baseURL });
     const response = await service.getFormStats();
-    expect(response).to.deep.equal(validStatsResponse);
+    expect(response).to.deep.equal(statsResponse);
   });
 
   it('sends a Bearer Authorization header and no customer_id when omitted', async function () {
-    let capturedConfig;
+    const scope = nock(baseURL, {
+      reqheaders: { authorization: 'Bearer ' + apiKey },
+    })
+      .get('/api/forms/stats')
+      .query({})
+      .reply(200, statsResponse);
 
-    axiosStub = sinon.stub(axios, 'create').returns(function (config) {
-      capturedConfig = config;
-      return Promise.resolve({ data: validStatsResponse });
-    });
-
-    const service = formService({ apiKey: apiKey });
+    const service = formService({ apiKey, baseURL });
     await service.getFormStats();
-
-    const createConfig = axiosStub.firstCall.args[0];
-    expect(createConfig.headers.Authorization).to.equal('Bearer ' + apiKey);
-    expect(capturedConfig.method).to.equal('GET');
-    expect(capturedConfig.url).to.equal('/api/forms/stats');
-    expect(capturedConfig.params).to.deep.equal({});
+    expect(scope.isDone()).to.equal(true);
   });
 
   it('sends the customer_id query param when provided', async function () {
-    let capturedConfig;
+    const scope = nock(baseURL)
+      .get('/api/forms/stats')
+      .query({ customer_id: customerId })
+      .reply(200, statsResponse);
 
-    axiosStub = sinon.stub(axios, 'create').returns(function (config) {
-      capturedConfig = config;
-      return Promise.resolve({ data: validStatsResponse });
-    });
-
-    const service = formService({ apiKey: apiKey });
-    await service.getFormStats(123);
-
-    expect(capturedConfig.url).to.equal('/api/forms/stats');
-    expect(capturedConfig.params).to.deep.equal({ customer_id: 123 });
+    const service = formService({ apiKey, baseURL });
+    await service.getFormStats(customerId);
+    expect(scope.isDone()).to.equal(true);
   });
 
-  it('throws an error if no apiKey was configured', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validStatsResponse });
-    });
+  it('propagates the request error without leaking the Authorization header', async function () {
+    nock(baseURL).get('/api/forms/stats').query(true).reply(400, { detail: 'Bad request' });
 
-    const savedApiKey = process.env.FORMS_API_KEY;
-    delete process.env.FORMS_API_KEY;
+    const service = formService({ apiKey, baseURL });
+    let caught;
     try {
-      const service = formService();
-      await expect(service.getFormStats()).to.be.rejectedWith('apiKey is required for this method');
-    } finally {
-      if (savedApiKey !== undefined) {
-        process.env.FORMS_API_KEY = savedApiKey;
-      }
+      await service.getFormStats('not-numeric');
+    } catch (error) {
+      caught = error;
     }
+
+    expect(caught, 'expected getFormStats to reject').to.not.equal(undefined);
+    expect(caught.response.status).to.equal(400);
+    expect(caught.config.headers).to.not.have.property('Authorization');
+    expect(JSON.stringify(caught)).to.not.contain(apiKey);
   });
 
-  it('throws the response if the request fails', async function () {
-    const errorMessage = 'Request failed with status code 401';
+  it('throws a shapeless-safe Error if an unexpected response is returned', async function () {
+    nock(baseURL).get('/api/forms/stats').query({}).reply(200, { unexpected: true });
 
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.reject({ message: errorMessage, response: { status: 401 } });
-    });
+    const service = formService({ apiKey, baseURL });
+    let caught;
+    try {
+      await service.getFormStats();
+    } catch (error) {
+      caught = error;
+    }
 
-    const service = formService({ apiKey: apiKey });
-    await expect(service.getFormStats()).to.be.rejectedWith(errorMessage);
-  });
-
-  it('throws the response if an unexpected response is returned', async function () {
-    const unexpectedResponse = { this: 'is not what we expected' };
-
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: unexpectedResponse });
-    });
-
-    const service = formService({ apiKey: apiKey });
-    await expect(service.getFormStats()).to.be.rejected.then((thrown) => {
-      expect(thrown).to.deep.equal(unexpectedResponse);
-    });
+    expect(caught).to.be.an.instanceof(Error);
+    expect(caught.message).to.equal('Unexpected response from Forms API');
   });
 });

--- a/test/getFormStats.test.js
+++ b/test/getFormStats.test.js
@@ -73,7 +73,8 @@ describe('formService.getFormStats', function () {
 
     expect(caught, 'expected getFormStats to reject').to.not.equal(undefined);
     expect(caught.response.status).to.equal(400);
-    expect(caught.config.headers).to.not.have.property('Authorization');
+    expect(caught).to.not.have.property('config');
+    expect(caught).to.not.have.property('request');
     expect(JSON.stringify(caught)).to.not.contain(apiKey);
   });
 

--- a/test/listForms.test.js
+++ b/test/listForms.test.js
@@ -146,7 +146,8 @@ describe('formService.listForms', function () {
 
     expect(caught, 'expected listForms to reject').to.not.equal(undefined);
     expect(caught.response.status).to.equal(401);
-    expect(caught.config.headers).to.not.have.property('Authorization');
+    expect(caught).to.not.have.property('config');
+    expect(caught).to.not.have.property('request');
     expect(JSON.stringify(caught)).to.not.contain(apiKey);
   });
 

--- a/test/listForms.test.js
+++ b/test/listForms.test.js
@@ -2,14 +2,15 @@ const chai = require('chai');
 const { expect } = chai;
 const chaiAsPromised = require('chai-as-promised').default;
 
-const sinon = require('sinon');
-const axios = require('axios');
+const nock = require('nock');
 
 const formService = require('../src/service/formService.js');
 
 chai.use(chaiAsPromised);
 
 const apiKey = 'test-scoped-api-key';
+const baseURL = 'https://forms.test';
+const customerId = 629;
 
 const validListResponse = {
   results: [
@@ -32,45 +33,56 @@ const validListResponse = {
 };
 
 describe('formService.listForms', function () {
-  let axiosStub;
+  beforeEach(() => {
+    nock.disableNetConnect();
+  });
 
-  this.afterEach(() => {
-    axiosStub.restore();
+  afterEach(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
   });
 
   it('can list forms', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validListResponse });
-    });
+    nock(baseURL)
+      .get('/api/forms')
+      .query({ customer_id: customerId })
+      .reply(200, validListResponse);
 
-    const service = formService({ apiKey: apiKey });
-    const response = await service.listForms();
+    const service = formService({ apiKey, baseURL });
+    const response = await service.listForms({ customer_id: customerId });
     expect(response).to.deep.equal(validListResponse);
   });
 
-  it('sends an Authorization header with the api key', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validListResponse });
-    });
+  it('sends a Bearer Authorization header with the api key', async function () {
+    const scope = nock(baseURL, {
+      reqheaders: { authorization: 'Bearer ' + apiKey },
+    })
+      .get('/api/forms')
+      .query({ customer_id: customerId })
+      .reply(200, validListResponse);
 
-    const service = formService({ apiKey: apiKey });
-    await service.listForms();
-
-    const createConfig = axiosStub.firstCall.args[0];
-    expect(createConfig.headers.Authorization).to.equal('Bearer ' + apiKey);
-    expect(createConfig.baseURL).to.equal('https://apx.paubox.com/forms');
+    const service = formService({ apiKey, baseURL });
+    await service.listForms({ customer_id: customerId });
+    expect(scope.isDone()).to.equal(true);
   });
 
-  it('sends only the provided query params', async function () {
-    let capturedConfig;
+  it('sends only the allow-listed query params', async function () {
+    const scope = nock(baseURL)
+      .get('/api/forms')
+      .query({
+        customer_id: customerId,
+        search: 'intake',
+        order: 'asc',
+        order_by: 'title',
+        archived: 'false',
+        page: 2,
+        items: 25,
+      })
+      .reply(200, validListResponse);
 
-    axiosStub = sinon.stub(axios, 'create').returns(function (config) {
-      capturedConfig = config;
-      return Promise.resolve({ data: validListResponse });
-    });
-
-    const service = formService({ apiKey: apiKey });
+    const service = formService({ apiKey, baseURL });
     await service.listForms({
+      customer_id: customerId,
       search: 'intake',
       order: 'asc',
       order_by: 'title',
@@ -79,58 +91,36 @@ describe('formService.listForms', function () {
       items: 25,
       unknown_param: 'should not be sent',
     });
-
-    expect(capturedConfig.method).to.equal('GET');
-    expect(capturedConfig.url).to.equal('/api/forms');
-    expect(capturedConfig.params).to.deep.equal({
-      search: 'intake',
-      order: 'asc',
-      order_by: 'title',
-      archived: false,
-      page: 2,
-      items: 25,
-    });
-  });
-
-  it('sends no query params when none are provided', async function () {
-    let capturedConfig;
-
-    axiosStub = sinon.stub(axios, 'create').returns(function (config) {
-      capturedConfig = config;
-      return Promise.resolve({ data: validListResponse });
-    });
-
-    const service = formService({ apiKey: apiKey });
-    await service.listForms();
-
-    expect(capturedConfig.params).to.deep.equal({});
+    expect(scope.isDone()).to.equal(true);
   });
 
   it('omits params that are null', async function () {
-    let capturedConfig;
+    const scope = nock(baseURL)
+      .get('/api/forms')
+      .query({ customer_id: customerId, page: 1 })
+      .reply(200, validListResponse);
 
-    axiosStub = sinon.stub(axios, 'create').returns(function (config) {
-      capturedConfig = config;
-      return Promise.resolve({ data: validListResponse });
-    });
+    const service = formService({ apiKey, baseURL });
+    await service.listForms({ customer_id: customerId, search: null, page: 1 });
+    expect(scope.isDone()).to.equal(true);
+  });
 
-    const service = formService({ apiKey: apiKey });
-    await service.listForms({ search: null, page: 1 });
-
-    expect(capturedConfig.params).to.deep.equal({ page: 1 });
+  it('throws before any request when customer_id is missing', async function () {
+    const service = formService({ apiKey, baseURL });
+    await expect(service.listForms()).to.be.rejectedWith('customer_id is required');
+    await expect(service.listForms({})).to.be.rejectedWith('customer_id is required');
+    await expect(service.listForms({ search: 'x' })).to.be.rejectedWith('customer_id is required');
+    // No nock interceptor was registered, so a leaked request would throw a
+    // net-connect error instead of the assertion above.
   });
 
   it('throws an error if no apiKey was configured', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validListResponse });
-    });
-
     const savedEnvKey = process.env.FORMS_API_KEY;
     delete process.env.FORMS_API_KEY;
 
     try {
-      const service = formService();
-      await expect(service.listForms()).to.be.rejectedWith(
+      const service = formService({ baseURL });
+      await expect(service.listForms({ customer_id: customerId })).to.be.rejectedWith(
         'apiKey is required for this method. Pass { apiKey } to formService() or set the FORMS_API_KEY environment variable.',
       );
     } finally {
@@ -140,25 +130,45 @@ describe('formService.listForms', function () {
     }
   });
 
-  it('throws the response if the request fails', async function () {
-    const errorMessage = 'Request failed with status code 401';
+  it('propagates the request error without leaking the Authorization header', async function () {
+    nock(baseURL)
+      .get('/api/forms')
+      .query({ customer_id: customerId })
+      .reply(401, { detail: 'Unauthorized' });
 
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.reject({ message: errorMessage, response: { status: 401 } });
-    });
+    const service = formService({ apiKey, baseURL });
+    let caught;
+    try {
+      await service.listForms({ customer_id: customerId });
+    } catch (error) {
+      caught = error;
+    }
 
-    const service = formService({ apiKey: apiKey });
-    await expect(service.listForms()).to.be.rejectedWith(errorMessage);
+    expect(caught, 'expected listForms to reject').to.not.equal(undefined);
+    expect(caught.response.status).to.equal(401);
+    expect(caught.config.headers).to.not.have.property('Authorization');
+    expect(JSON.stringify(caught)).to.not.contain(apiKey);
   });
 
-  it('throws the response if an unexpected response is returned', async function () {
-    const unexpectedResponse = { this: 'is not what we expected' };
+  it('throws a shapeless-safe Error if an unexpected response is returned', async function () {
+    nock(baseURL)
+      .get('/api/forms')
+      .query({ customer_id: customerId })
+      .reply(200, { this: 'is not what we expected' });
 
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: unexpectedResponse });
-    });
+    const service = formService({ apiKey, baseURL });
+    let caught;
+    try {
+      await service.listForms({ customer_id: customerId });
+    } catch (error) {
+      caught = error;
+    }
 
-    const service = formService({ apiKey: apiKey });
-    await expect(service.listForms()).to.be.rejected.and.eventually.deep.equal(unexpectedResponse);
+    expect(caught).to.be.an.instanceof(Error);
+    expect(caught.message).to.equal('Unexpected response from Forms API');
+    // Body is reachable for debugging but not enumerable (so a logger that
+    // stringifies the error can't spill response content).
+    expect(Object.keys(caught)).to.not.include('body');
+    expect(caught.body).to.deep.equal({ this: 'is not what we expected' });
   });
 });

--- a/test/listSubmissions.test.js
+++ b/test/listSubmissions.test.js
@@ -82,7 +82,8 @@ describe('formService.listSubmissions', function () {
 
     expect(caught, 'expected listSubmissions to reject').to.not.equal(undefined);
     expect(caught.response.status).to.equal(404);
-    expect(caught.config.headers).to.not.have.property('Authorization');
+    expect(caught).to.not.have.property('config');
+    expect(caught).to.not.have.property('request');
     expect(JSON.stringify(caught)).to.not.contain(apiKey);
   });
 });

--- a/test/listSubmissions.test.js
+++ b/test/listSubmissions.test.js
@@ -2,133 +2,87 @@ const chai = require('chai');
 const { expect } = chai;
 const chaiAsPromised = require('chai-as-promised').default;
 
-const sinon = require('sinon');
-const axios = require('axios');
+const nock = require('nock');
 
 const formService = require('../src/service/formService.js');
 
 chai.use(chaiAsPromised);
 
 const apiKey = 'test-scoped-api-key';
+const baseURL = 'https://forms.test';
 const formId = '550e8400-e29b-41d4-a716-446655440000';
 
-const validListResponse = {
-  data: [
-    {
-      id: 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d',
-      form_id: formId,
-      form_data: '{"first_name":"Jane","last_name":"Smith"}',
-      storage_type: null,
-      storage_url: null,
-      submitter_email: 'jane@example.com',
-      recipients: 'clinic@example.com',
-      attachment_name: null,
-      attachment_url: null,
-      attachment_type: null,
-      attachment: null,
-      created_at: '2024-06-01T08:00:00Z',
-    },
-  ],
+const validSubmissionsResponse = {
+  data: [{ id: 'b3b8c7e2-1d2f-4c5a-9e8d-7f6a5b4c3d2e', submitter_email: 'test@example.com' }],
   total: 1,
   page: 1,
   items: 50,
 };
 
 describe('formService.listSubmissions', function () {
-  let axiosStub;
+  beforeEach(() => {
+    nock.disableNetConnect();
+  });
 
-  this.afterEach(() => {
-    axiosStub.restore();
+  afterEach(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
   });
 
   it('can list submissions', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validListResponse });
-    });
+    nock(baseURL)
+      .get('/api/forms/' + formId + '/submissions')
+      .reply(200, validSubmissionsResponse);
 
-    const service = formService({ apiKey: apiKey });
+    const service = formService({ apiKey, baseURL });
     const response = await service.listSubmissions(formId);
-    expect(response).to.deep.equal(validListResponse);
+    expect(response).to.deep.equal(validSubmissionsResponse);
   });
 
-  it('sends the Authorization header and only the provided query params', async function () {
-    let capturedConfig;
+  it('sends the Bearer Authorization header and only the allow-listed query params', async function () {
+    const scope = nock(baseURL, {
+      reqheaders: { authorization: 'Bearer ' + apiKey },
+    })
+      .get('/api/forms/' + formId + '/submissions')
+      .query({ order_by: 'submitter_email', order: 'asc', page: 1, items: 25 })
+      .reply(200, validSubmissionsResponse);
 
-    axiosStub = sinon.stub(axios, 'create').returns(function (config) {
-      capturedConfig = config;
-      return Promise.resolve({ data: validListResponse });
+    const service = formService({ apiKey, baseURL });
+    await service.listSubmissions(formId, {
+      order_by: 'submitter_email',
+      order: 'asc',
+      page: 1,
+      items: 25,
+      unknown_param: 'drop me',
     });
-
-    const service = formService({ apiKey: apiKey });
-    await service.listSubmissions(formId, { order: 'asc', page: 2, items: 25 });
-
-    const createConfig = axiosStub.getCall(0).args[0];
-    expect(createConfig.headers.Authorization).to.equal('Bearer test-scoped-api-key');
-    expect(capturedConfig.url).to.equal(`/api/forms/${formId}/submissions`);
-    expect(capturedConfig.params).to.deep.equal({ order: 'asc', page: 2, items: 25 });
+    expect(scope.isDone()).to.equal(true);
   });
 
-  it('sends no query params when none are provided', async function () {
-    let capturedConfig;
-
-    axiosStub = sinon.stub(axios, 'create').returns(function (config) {
-      capturedConfig = config;
-      return Promise.resolve({ data: validListResponse });
-    });
-
-    const service = formService({ apiKey: apiKey });
-    await service.listSubmissions(formId);
-    expect(capturedConfig.params).to.deep.equal({});
-  });
-
-  it('throws an error if formId is not provided', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validListResponse });
-    });
-
-    const service = formService({ apiKey: apiKey });
-    await expect(service.listSubmissions()).to.be.rejectedWith('formId is required');
-  });
-
-  it('throws an error if no apiKey was configured', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validListResponse });
-    });
-
-    const savedEnvKey = process.env.FORMS_API_KEY;
-    delete process.env.FORMS_API_KEY;
-
-    try {
-      const service = formService();
-      await expect(service.listSubmissions(formId)).to.be.rejectedWith(
-        'apiKey is required for this method',
+  it('throws before any request when formId is not a UUID', async function () {
+    const service = formService({ apiKey, baseURL });
+    for (const bad of ['..', 'a?b=1', 'a#b', '', undefined]) {
+      await expect(service.listSubmissions(bad)).to.be.rejectedWith(
+        /formId (is required|must be a UUID)/,
       );
-    } finally {
-      if (savedEnvKey !== undefined) {
-        process.env.FORMS_API_KEY = savedEnvKey;
-      }
     }
   });
 
-  it('throws the response if the request fails', async function () {
-    const errorMessage = 'Request failed with status code 401';
+  it('propagates the request error without leaking the Authorization header', async function () {
+    nock(baseURL)
+      .get('/api/forms/' + formId + '/submissions')
+      .reply(404, { detail: 'Not found' });
 
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.reject({ message: errorMessage, response: { status: 401 } });
-    });
+    const service = formService({ apiKey, baseURL });
+    let caught;
+    try {
+      await service.listSubmissions(formId);
+    } catch (error) {
+      caught = error;
+    }
 
-    const service = formService({ apiKey: apiKey });
-    await expect(service.listSubmissions(formId)).to.be.rejectedWith(errorMessage);
-  });
-
-  it('throws the response if an unexpected response is returned', async function () {
-    const unexpectedResponse = { this: 'is not what we expected' };
-
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: unexpectedResponse });
-    });
-
-    const service = formService({ apiKey: apiKey });
-    await expect(service.listSubmissions(formId)).to.be.rejected;
+    expect(caught, 'expected listSubmissions to reject').to.not.equal(undefined);
+    expect(caught.response.status).to.equal(404);
+    expect(caught.config.headers).to.not.have.property('Authorization');
+    expect(JSON.stringify(caught)).to.not.contain(apiKey);
   });
 });

--- a/test/unarchiveForm.test.js
+++ b/test/unarchiveForm.test.js
@@ -2,108 +2,75 @@ const chai = require('chai');
 const { expect } = chai;
 const chaiAsPromised = require('chai-as-promised').default;
 
-const sinon = require('sinon');
-const axios = require('axios');
+const nock = require('nock');
 
 const formService = require('../src/service/formService.js');
 
 chai.use(chaiAsPromised);
 
-const formId = '550e8400-e29b-41d4-a716-446655440000';
 const apiKey = 'test-scoped-api-key';
+const baseURL = 'https://forms.test';
+const formId = '550e8400-e29b-41d4-a716-446655440000';
 
-const validUnarchiveResponse = { detail: 'Form unarchived.' };
+const unarchivedResponse = { detail: 'Form unarchived.' };
 
 describe('formService.unarchiveForm', function () {
-  let axiosStub;
-  let savedFormsApiKey;
-
-  this.beforeEach(() => {
-    savedFormsApiKey = process.env.FORMS_API_KEY;
-    delete process.env.FORMS_API_KEY;
+  beforeEach(() => {
+    nock.disableNetConnect();
   });
 
-  this.afterEach(() => {
-    if (savedFormsApiKey !== undefined) {
-      process.env.FORMS_API_KEY = savedFormsApiKey;
-    } else {
-      delete process.env.FORMS_API_KEY;
-    }
-    if (axiosStub) {
-      axiosStub.restore();
-      axiosStub = undefined;
-    }
+  afterEach(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
   });
 
   it('can unarchive a form', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validUnarchiveResponse });
-    });
+    nock(baseURL)
+      .post('/api/forms/' + formId + '/unarchive')
+      .reply(200, unarchivedResponse);
 
-    const service = formService({ apiKey });
+    const service = formService({ apiKey, baseURL });
     const response = await service.unarchiveForm(formId);
-    expect(response).to.deep.equal(validUnarchiveResponse);
+    expect(response).to.deep.equal(unarchivedResponse);
   });
 
   it('sends a Bearer Authorization header and POSTs to the unarchive endpoint', async function () {
-    let capturedConfig;
+    const scope = nock(baseURL, {
+      reqheaders: { authorization: 'Bearer ' + apiKey },
+    })
+      .post('/api/forms/' + formId + '/unarchive')
+      .reply(200, unarchivedResponse);
 
-    axiosStub = sinon.stub(axios, 'create').returns(function (config) {
-      capturedConfig = config;
-      return Promise.resolve({ data: validUnarchiveResponse });
-    });
-
-    const service = formService({ apiKey });
+    const service = formService({ apiKey, baseURL });
     await service.unarchiveForm(formId);
-
-    const createConfig = axiosStub.getCall(0).args[0];
-    expect(createConfig.headers.Authorization).to.equal('Bearer test-scoped-api-key');
-    expect(createConfig.baseURL).to.equal('https://apx.paubox.com/forms');
-
-    expect(capturedConfig.method).to.equal('POST');
-    expect(capturedConfig.url).to.equal(`/api/forms/${formId}/unarchive`);
-    expect(capturedConfig.data).to.be.undefined;
+    expect(scope.isDone()).to.equal(true);
   });
 
-  it('throws an error if formId is not provided', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validUnarchiveResponse });
-    });
-
-    const service = formService({ apiKey });
-    await expect(service.unarchiveForm()).to.be.rejectedWith('formId is required');
+  it('throws before any request when formId is not a UUID', async function () {
+    const service = formService({ apiKey, baseURL });
+    for (const bad of ['..', 'a?b=1', 'a#b', '', undefined]) {
+      await expect(service.unarchiveForm(bad)).to.be.rejectedWith(
+        /formId (is required|must be a UUID)/,
+      );
+    }
   });
 
-  it('throws an error if no apiKey was configured', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validUnarchiveResponse });
-    });
+  it('propagates the request error without leaking the Authorization header', async function () {
+    nock(baseURL)
+      .post('/api/forms/' + formId + '/unarchive')
+      .reply(404, { detail: 'Not found' });
 
-    const service = formService();
-    await expect(service.unarchiveForm(formId)).to.be.rejectedWith(
-      'apiKey is required for this method. Pass { apiKey } to formService() or set the FORMS_API_KEY environment variable.',
-    );
-  });
+    const service = formService({ apiKey, baseURL });
+    let caught;
+    try {
+      await service.unarchiveForm(formId);
+    } catch (error) {
+      caught = error;
+    }
 
-  it('throws the response if the request fails', async function () {
-    const errorMessage = 'Request failed with status code 404';
-
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.reject({ message: errorMessage, response: { status: 404 } });
-    });
-
-    const service = formService({ apiKey });
-    await expect(service.unarchiveForm(formId)).to.be.rejectedWith(errorMessage);
-  });
-
-  it('throws the response if an unexpected response is returned', async function () {
-    const unexpectedResponse = { this: 'is not what we expected' };
-
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: unexpectedResponse });
-    });
-
-    const service = formService({ apiKey });
-    await expect(service.unarchiveForm(formId)).to.be.rejected;
+    expect(caught, 'expected unarchiveForm to reject').to.not.equal(undefined);
+    expect(caught.response.status).to.equal(404);
+    expect(caught.config.headers).to.not.have.property('Authorization');
+    expect(JSON.stringify(caught)).to.not.contain(apiKey);
   });
 });

--- a/test/unarchiveForm.test.js
+++ b/test/unarchiveForm.test.js
@@ -70,7 +70,8 @@ describe('formService.unarchiveForm', function () {
 
     expect(caught, 'expected unarchiveForm to reject').to.not.equal(undefined);
     expect(caught.response.status).to.equal(404);
-    expect(caught.config.headers).to.not.have.property('Authorization');
+    expect(caught).to.not.have.property('config');
+    expect(caught).to.not.have.property('request');
     expect(JSON.stringify(caught)).to.not.contain(apiKey);
   });
 });

--- a/test/updateForm.test.js
+++ b/test/updateForm.test.js
@@ -2,163 +2,106 @@ const chai = require('chai');
 const { expect } = chai;
 const chaiAsPromised = require('chai-as-promised').default;
 
-const sinon = require('sinon');
-const axios = require('axios');
+const nock = require('nock');
 
 const formService = require('../src/service/formService.js');
 
 chai.use(chaiAsPromised);
 
-const formId = '550e8400-e29b-41d4-a716-446655440000';
 const apiKey = 'test-scoped-api-key';
+const baseURL = 'https://forms.test';
+const formId = '550e8400-e29b-41d4-a716-446655440000';
 
-const validUpdateResponse = {
-  detail: 'Form updated successfully',
-  form_id: formId,
-};
+const updatedResponse = { detail: 'Form updated.', form_id: formId };
 
 describe('formService.updateForm', function () {
-  let axiosStub;
-  let savedFormsApiKey;
-
-  this.beforeEach(() => {
-    savedFormsApiKey = process.env.FORMS_API_KEY;
-    delete process.env.FORMS_API_KEY;
+  beforeEach(() => {
+    nock.disableNetConnect();
   });
 
-  this.afterEach(() => {
-    if (savedFormsApiKey !== undefined) {
-      process.env.FORMS_API_KEY = savedFormsApiKey;
-    } else {
-      delete process.env.FORMS_API_KEY;
-    }
-    if (axiosStub) {
-      axiosStub.restore();
-      axiosStub = undefined;
-    }
+  afterEach(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
   });
 
   it('can update a form', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validUpdateResponse });
-    });
+    nock(baseURL)
+      .put('/api/forms/' + formId, { title: 'New title' })
+      .reply(200, updatedResponse);
 
-    const service = formService({ apiKey });
-    const response = await service.updateForm(formId, { title: 'New Title' });
-    expect(response).to.deep.equal(validUpdateResponse);
+    const service = formService({ apiKey, baseURL });
+    const response = await service.updateForm(formId, { title: 'New title' });
+    expect(response).to.deep.equal(updatedResponse);
   });
 
-  it('sends a Bearer Authorization header and PUTs only the provided updatable keys', async function () {
-    let capturedConfig;
+  it('sends a Bearer Authorization header and PUTs only the allow-listed keys', async function () {
+    const scope = nock(baseURL, {
+      reqheaders: { authorization: 'Bearer ' + apiKey },
+    })
+      .put('/api/forms/' + formId, {
+        title: 'New title',
+        description: 'New desc',
+        active: false,
+      })
+      .reply(200, updatedResponse);
 
-    axiosStub = sinon.stub(axios, 'create').returns(function (config) {
-      capturedConfig = config;
-      return Promise.resolve({ data: validUpdateResponse });
-    });
-
-    const service = formService({ apiKey });
+    const service = formService({ apiKey, baseURL });
     await service.updateForm(formId, {
-      title: 'New Title',
+      title: 'New title',
+      description: 'New desc',
       active: false,
-      not_updatable: 'ignore me',
+      not_allowed: 'drop me',
     });
-
-    const createConfig = axiosStub.getCall(0).args[0];
-    expect(createConfig.headers.Authorization).to.equal('Bearer test-scoped-api-key');
-    expect(createConfig.baseURL).to.equal('https://apx.paubox.com/forms');
-
-    expect(capturedConfig.method).to.equal('PUT');
-    expect(capturedConfig.url).to.equal(`/api/forms/${formId}`);
-    expect(capturedConfig.data).to.deep.equal({ title: 'New Title', active: false });
+    expect(scope.isDone()).to.equal(true);
   });
 
-  it('throws an error if formId is not provided', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validUpdateResponse });
-    });
-
-    const service = formService({ apiKey });
-    await expect(service.updateForm(null, { title: 'New Title' })).to.be.rejectedWith(
-      'formId is required',
-    );
-  });
-
-  it('throws an error if updates is not provided', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validUpdateResponse });
-    });
-
-    const service = formService({ apiKey });
-    await expect(service.updateForm(formId)).to.be.rejectedWith(
-      'updates is required and must be an object',
-    );
-  });
-
-  it('throws an error if updates is not an object', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validUpdateResponse });
-    });
-
-    const service = formService({ apiKey });
-    await expect(service.updateForm(formId, 'not an object')).to.be.rejectedWith(
-      'updates is required and must be an object',
-    );
-  });
-
-  it('throws an error if updates is an array', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validUpdateResponse });
-    });
-
-    const service = formService({ apiKey });
-    await expect(service.updateForm(formId, ['title'])).to.be.rejectedWith(
-      'updates is required and must be an object',
-    );
-  });
-
-  it('throws an error if updates contains no updatable fields', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validUpdateResponse });
-    });
-
-    const service = formService({ apiKey });
-    await expect(service.updateForm(formId, { not_updatable: 'value' })).to.be.rejectedWith(
+  it('does not send vanity_url (dropped from the updatable set)', async function () {
+    // vanity_url is accepted-but-not-persisted server-side, so the SDK no
+    // longer forwards it. With only vanity_url provided, no updatable field
+    // remains and the call must throw before any request.
+    const service = formService({ apiKey, baseURL });
+    await expect(service.updateForm(formId, { vanity_url: 'my-form' })).to.be.rejectedWith(
       'updates must include at least one updatable field',
     );
   });
 
-  it('throws an error if no apiKey was configured', async function () {
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: validUpdateResponse });
-    });
-
-    const service = formService();
-    await expect(service.updateForm(formId, { title: 'New Title' })).to.be.rejectedWith(
-      'apiKey is required for this method. Pass { apiKey } to formService() or set the FORMS_API_KEY environment variable.',
-    );
+  it('throws before any request when formId is not a UUID', async function () {
+    const service = formService({ apiKey, baseURL });
+    for (const bad of ['..', 'a?b=1', 'a#b', '', undefined]) {
+      await expect(service.updateForm(bad, { title: 'x' })).to.be.rejectedWith(
+        /formId (is required|must be a UUID)/,
+      );
+    }
   });
 
-  it('throws the response if the request fails', async function () {
-    const errorMessage = 'Request failed with status code 404';
-
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.reject({ message: errorMessage, response: { status: 404 } });
-    });
-
-    const service = formService({ apiKey });
-    await expect(service.updateForm(formId, { title: 'New Title' })).to.be.rejectedWith(
-      errorMessage,
+  it('throws before any request when updates is empty or not an object', async function () {
+    const service = formService({ apiKey, baseURL });
+    await expect(service.updateForm(formId, { bogus_key: 'anything' })).to.be.rejectedWith(
+      'updates must include at least one updatable field',
     );
+    for (const bad of [null, 'x', [1, 2]]) {
+      await expect(service.updateForm(formId, bad)).to.be.rejectedWith(
+        'updates is required and must be an object',
+      );
+    }
   });
 
-  it('throws the response if an unexpected response is returned', async function () {
-    const unexpectedResponse = { this: 'is not what we expected' };
+  it('propagates the request error without leaking the Authorization header', async function () {
+    nock(baseURL)
+      .put('/api/forms/' + formId)
+      .reply(404, { detail: 'Not found' });
 
-    axiosStub = sinon.stub(axios, 'create').returns(function (_config) {
-      return Promise.resolve({ data: unexpectedResponse });
-    });
+    const service = formService({ apiKey, baseURL });
+    let caught;
+    try {
+      await service.updateForm(formId, { title: 'x' });
+    } catch (error) {
+      caught = error;
+    }
 
-    const service = formService({ apiKey });
-    await expect(service.updateForm(formId, { title: 'New Title' })).to.be.rejected;
+    expect(caught, 'expected updateForm to reject').to.not.equal(undefined);
+    expect(caught.response.status).to.equal(404);
+    expect(caught.config.headers).to.not.have.property('Authorization');
+    expect(JSON.stringify(caught)).to.not.contain(apiKey);
   });
 });

--- a/test/updateForm.test.js
+++ b/test/updateForm.test.js
@@ -101,7 +101,8 @@ describe('formService.updateForm', function () {
 
     expect(caught, 'expected updateForm to reject').to.not.equal(undefined);
     expect(caught.response.status).to.equal(404);
-    expect(caught.config.headers).to.not.have.property('Authorization');
+    expect(caught).to.not.have.property('config');
+    expect(caught).to.not.have.property('request');
     expect(JSON.stringify(caught)).to.not.contain(apiKey);
   });
 });


### PR DESCRIPTION
## Summary

Addresses the pre-handoff QA-gate findings on PR #56 (authenticated Forms API via scoped API keys) so the change can clear the gate and go to QA. Targets `feat/scoped-api-keys`; merge here updates #56.

Each gate item is fixed, one concern per bullet:

| # | Finding | Fix |
|---|---------|-----|
| 2 | `listForms()` 403s without `customer_id`, but SDK/docs treat it as optional | `customer_id` is now required and throws before any HTTP when absent; README + `api.md` updated |
| 3 | `subscription_list_id` documented as `number`, server takes `string` | `api.md` retyped to `string` |
| 4 | `vanity_url` advertised as updatable but silently discarded server-side | dropped from `updateForm`'s updatable set (src + `api.md`) |
| 5 | API key reachable from every propagated error; README examples serialize the whole error | response interceptor strips `Authorization` (and the raw request header) off propagated errors; the six new README examples log `message`/`status`/`data` only |
| 6 | `formId`/`submissionId` interpolated into URLs with only a truthiness check | new `_pathSegment` helper UUID-validates + `encodeURIComponent`s at all 9 authenticated sites; public `getForm`/`submitForm` encode without requiring a UUID |
| 7 | `throw response.data` loses `Error` semantics and can serialize response bodies | replaced with a real `Error` carrying the body on a **non-enumerable** property |
| 8 | `baseURL` hardcoded → mutating methods only exercisable in prod | overridable via `{ baseURL }` config or `FORMS_BASE_URL` env (config wins); documented |
| 9 | `CLAUDE.md` named the wrong Forms API host | corrected |

## Test plan

- [x] `npm test` — 136 passing, 0 failing.
- [x] `npm run lint` — clean (`--max-warnings 0`).
- [x] `npm run build` — `lib/` rebuilt; only `lib/service/formService.js` changed.

The per-method test files were rewritten from wholesale `axios.create` stubs to **nock**, pinning method + path + query + body against real axios instances — so the new interceptor and URL validation are actually exercised (this is the contract-drift gap called out in gate item 1). New `test/formServiceSecurity.test.js` adds:

- a no-retarget sweep: every id-path method rejects `..`, `../..`, `..%2F..`, `<uuid>/archive`, `a?x=1`, `a#frag`, `a b` **before** any request goes out (net-connect disabled, so a leaked request would fail differently);
- an `Authorization`-not-leaked assertion across all 11 authenticated methods on a propagated error.

## Out of scope

The pre-existing `JSON.stringify(error)` pattern in the `emailService` and public `getForm`/`submitForm` README examples is left untouched — it predates this work and doesn't attach a Forms bearer. Worth a follow-up, but not part of this gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
