### PR TITLE
Remove apiUsername requirement and move base URL host to api.paubox.com

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,8 @@
 
 `paubox-node` is the official Node.js SDK for the Paubox platform. It exposes two services:
 
-- **emailService** — authenticated REST client for the Paubox Email API (`api.paubox.net/v1/`). Sends messages, tracks delivery, and manages dynamic Handlebars templates.
-- **formService** — REST client for the Paubox Forms API (`apx.paubox.com/forms`). Fetches form definitions and submits form responses without credentials, and also supports authenticated form-management endpoints (list/create/update/archive/copy forms, stats, submissions, CSV/PDF exports) via an optional scoped API key.
+- **emailService** — authenticated REST client for the Paubox Email API (`api.paubox.com/v1/`). Sends messages, tracks delivery, and manages dynamic Handlebars templates.
+- **formService** — REST client for the Paubox Forms API (`api.paubox.com/forms`). Fetches form definitions and submits form responses without credentials, and also supports authenticated form-management endpoints (list/create/update/archive/copy forms, stats, submissions, CSV/PDF exports) via an optional scoped API key.
 
 ## Repository layout
 
@@ -28,15 +28,15 @@ index.js                 # Public exports: emailService, formService, message, t
 
 ### emailService
 
-- Constructor requires `apiUsername` and `apiKey` (or env vars `API_USERNAME` / `API_KEY`).
+- Constructor requires `apiKey` (or env var `API_KEY`). A legacy `apiUsername` in the config is accepted and ignored.
 - All requests use `apiHelper`, which injects `Authorization: Token token=<apiKey>`.
-- Base URL: `https://api.paubox.net/v1/<apiUsername>/`.
+- Base URL: `https://api.paubox.com/v1/`.
 - Dynamic template uploads use `FormData` (multipart); all other requests are JSON.
 - Response validation: methods inspect well-known fields and throw the raw response if unexpected.
 
 ### formService
 
-- Base URL: `https://apx.paubox.com/forms`.
+- Base URL: `https://api.paubox.com/forms` (overridable via `config.baseURL` or `FORMS_BASE_URL`).
 - Uses `axios.create` directly (no `apiHelper`).
 - `getForm` and `submitForm` remain unauthenticated — public endpoints called by form respondents; they never send an Authorization header.
 - `getForm` validates that the response contains an `id` field before returning.

--- a/README.md
+++ b/README.md
@@ -62,13 +62,10 @@ Once you have an account, follow the instructions on the Rest API dashboard to v
 
 Include your API credentials in your environment file.
 
-Your "API Username" comes from your unique API endpoint.
-
-**Base URL:** `https://api.paubox.net/v1/<USERNAME>`
+**Base URL:** `https://api.paubox.com/v1/`
 
 ```bash
 echo "API_KEY='YOUR_API_KEY'" > .env
-echo "API_USERNAME='YOUR_ENDPOINT_NAME'" >> .env
 echo ".env" >> .gitignore
 ```
 
@@ -77,7 +74,6 @@ Or pass them as parameters when creating emailService
 ```javascript
 const pbMail = require('paubox-node');
 const pauboxConfig = {
-  apiUsername: 'your-api-username',
   apiKey: 'your-api-key',
 };
 const service = pbMail.emailService(pauboxConfig);
@@ -539,7 +535,7 @@ service
 
 ### Paubox Forms
 
-The Paubox Forms endpoints for fetching a form definition and submitting responses are **public** — no API key or username is required. Use `pbMail.formService()` to get a service instance. Form-management endpoints require a scoped API key — see [Authenticated form management](#authenticated-form-management) below.
+The Paubox Forms endpoints for fetching a form definition and submitting responses are **public** — no API key is required. Use `pbMail.formService()` to get a service instance. Form-management endpoints require a scoped API key — see [Authenticated form management](#authenticated-form-management) below.
 
 #### Get Form
 
@@ -647,12 +643,12 @@ const service = pbMail.formService(); // reads FORMS_API_KEY from the environmen
 
 Calling an authenticated method without an API key throws an error. The public `getForm` and `submitForm` methods work with or without a key.
 
-The service targets production (`https://apx.paubox.com/forms`) by default. To point it at another environment, pass `{ baseURL }` or set the `FORMS_BASE_URL` environment variable (config wins over the env var):
+The service targets production (`https://api.paubox.com/forms`) by default. To point it at another environment, pass `{ baseURL }` or set the `FORMS_BASE_URL` environment variable (config wins over the env var):
 
 ```javascript
 const service = pbMail.formService({
   apiKey: 'your-scoped-api-key',
-  baseURL: 'https://apx.staging.paubox.com/forms',
+  baseURL: 'https://api.staging.paubox.com/forms',
 });
 ```
 

--- a/api.md
+++ b/api.md
@@ -10,10 +10,10 @@ Create a service instance to send email and manage dynamic templates.
 
 ```javascript
 const pbMail = require('paubox-node');
-const service = pbMail.emailService({ apiUsername: '...', apiKey: '...' });
+const service = pbMail.emailService({ apiKey: '...' });
 ```
 
-Credentials can also be loaded from environment variables `API_USERNAME` and `API_KEY`.
+The API key can also be loaded from the environment variable `API_KEY`.
 
 ---
 
@@ -164,7 +164,7 @@ const service = pbMail.formService({ apiKey: 'your-scoped-api-key' });
 
 Calling an authenticated method without an API key throws an error.
 
-Base URL: `https://apx.paubox.com/forms`
+Base URL: `https://api.paubox.com/forms`
 
 ---
 

--- a/lib/service/emailService.js
+++ b/lib/service/emailService.js
@@ -7,7 +7,6 @@ class emailService {
   constructor(config) {
     config = Object.assign(
       {
-        apiUsername: process.env.API_USERNAME,
         apiKey: process.env.API_KEY,
       },
       config,
@@ -15,16 +14,12 @@ class emailService {
     if (!config.apiKey) {
       throw new Error('apiKey is missing.');
     }
-    if (!config.apiUsername) {
-      throw new Error('apiUsername is missing.');
-    }
     this.apiKey = config.apiKey;
-    this.apiUser = config.apiUsername;
     this.protocol = 'https:';
-    this.host = 'api.paubox.net';
+    this.host = 'api.paubox.com';
     this.port = 443;
     this.version = 'v1';
-    this.baseURL = `${this.protocol}//${this.host}/${this.version}/${this.apiUser}/`;
+    this.baseURL = `${this.protocol}//${this.host}/${this.version}/`;
     this.apiHelper = apiHelper(`Token token=${this.apiKey}`);
   }
 

--- a/lib/service/formService.js
+++ b/lib/service/formService.js
@@ -10,7 +10,7 @@ class formService {
       },
       config,
     );
-    this.baseURL = config.baseURL || 'https://apx.paubox.com/forms';
+    this.baseURL = config.baseURL || 'https://api.paubox.com/forms';
     this.apiKey = config.apiKey || null;
   }
 

--- a/src/service/emailService.js
+++ b/src/service/emailService.js
@@ -8,7 +8,6 @@ class emailService {
   constructor(config) {
     config = Object.assign(
       {
-        apiUsername: process.env.API_USERNAME,
         apiKey: process.env.API_KEY,
       },
       config,
@@ -17,16 +16,12 @@ class emailService {
     if (!config.apiKey) {
       throw new Error('apiKey is missing.');
     }
-    if (!config.apiUsername) {
-      throw new Error('apiUsername is missing.');
-    }
     this.apiKey = config.apiKey;
-    this.apiUser = config.apiUsername;
     this.protocol = 'https:';
-    this.host = 'api.paubox.net';
+    this.host = 'api.paubox.com';
     this.port = 443;
     this.version = 'v1';
-    this.baseURL = `${this.protocol}//${this.host}/${this.version}/${this.apiUser}/`;
+    this.baseURL = `${this.protocol}//${this.host}/${this.version}/`;
 
     this.apiHelper = apiHelper(`Token token=${this.apiKey}`);
   }

--- a/src/service/formService.js
+++ b/src/service/formService.js
@@ -11,7 +11,7 @@ class formService {
       },
       config,
     );
-    this.baseURL = config.baseURL || 'https://apx.paubox.com/forms';
+    this.baseURL = config.baseURL || 'https://api.paubox.com/forms';
     this.apiKey = config.apiKey || null;
   }
 

--- a/test/createDynamicTemplate.test.js
+++ b/test/createDynamicTemplate.test.js
@@ -11,7 +11,6 @@ const emailService = require('../src/service/emailService.js');
 chai.use(chaiAsPromised);
 
 const testCredentials = {
-  apiUsername: 'authorized_domain',
   apiKey: 'api-key-12345',
 };
 

--- a/test/deleteDynamicTemplate.test.js
+++ b/test/deleteDynamicTemplate.test.js
@@ -10,7 +10,6 @@ const emailService = require('../src/service/emailService.js');
 chai.use(chaiAsPromised);
 
 const testCredentials = {
-  apiUsername: 'authorized_domain',
   apiKey: 'api-key-12345',
 };
 

--- a/test/emailServiceConstructor.test.js
+++ b/test/emailServiceConstructor.test.js
@@ -1,0 +1,47 @@
+const chai = require('chai');
+const { expect } = chai;
+
+const emailService = require('../src/service/emailService.js');
+
+describe('emailService constructor', function () {
+  it('constructs with only an apiKey and uses the versioned base URL', function () {
+    const service = emailService({ apiKey: 'api-key-12345' });
+    expect(service.baseURL).to.equal('https://api.paubox.com/v1/');
+  });
+
+  it('ignores a legacy apiUsername without throwing', function () {
+    const service = emailService({
+      apiUsername: 'authorized_domain',
+      apiKey: 'api-key-12345',
+    });
+    expect(service.baseURL).to.equal('https://api.paubox.com/v1/');
+    expect(service.apiUser).to.equal(undefined);
+  });
+
+  it('falls back to the API_KEY environment variable', function () {
+    const saved = process.env.API_KEY;
+    process.env.API_KEY = 'env-api-key';
+    try {
+      const service = emailService();
+      expect(service.baseURL).to.equal('https://api.paubox.com/v1/');
+    } finally {
+      if (saved === undefined) {
+        delete process.env.API_KEY;
+      } else {
+        process.env.API_KEY = saved;
+      }
+    }
+  });
+
+  it('throws when no apiKey is configured', function () {
+    const saved = process.env.API_KEY;
+    delete process.env.API_KEY;
+    try {
+      expect(() => emailService()).to.throw('apiKey is missing.');
+    } finally {
+      if (saved !== undefined) {
+        process.env.API_KEY = saved;
+      }
+    }
+  });
+});

--- a/test/formServiceSecurity.test.js
+++ b/test/formServiceSecurity.test.js
@@ -180,7 +180,7 @@ describe('formService baseURL resolution', function () {
     const saved = process.env.FORMS_BASE_URL;
     delete process.env.FORMS_BASE_URL;
     try {
-      expect(formService({ apiKey }).baseURL).to.equal('https://apx.paubox.com/forms');
+      expect(formService({ apiKey }).baseURL).to.equal('https://api.paubox.com/forms');
     } finally {
       if (saved !== undefined) {
         process.env.FORMS_BASE_URL = saved;

--- a/test/getDynamicTemplate.test.js
+++ b/test/getDynamicTemplate.test.js
@@ -10,7 +10,6 @@ const emailService = require('../src/service/emailService.js');
 chai.use(chaiAsPromised);
 
 const testCredentials = {
-  apiUsername: 'authorized_domain',
   apiKey: 'api-key-12345',
 };
 

--- a/test/getEmailDisposition.test.js
+++ b/test/getEmailDisposition.test.js
@@ -10,7 +10,6 @@ const emailService = require('../src/service/emailService.js');
 chai.use(chaiAsPromised);
 
 const testCredentials = {
-  apiUsername: 'authorized_domain',
   apiKey: 'api-key-12345',
 };
 

--- a/test/listDynamicTemplates.test.js
+++ b/test/listDynamicTemplates.test.js
@@ -10,7 +10,6 @@ const emailService = require('../src/service/emailService.js');
 chai.use(chaiAsPromised);
 
 const testCredentials = {
-  apiUsername: 'authorized_domain',
   apiKey: 'api-key-12345',
 };
 

--- a/test/sendBulkMessages.test.js
+++ b/test/sendBulkMessages.test.js
@@ -11,7 +11,6 @@ const Message = require('../src/data/message.js');
 chai.use(chaiAsPromised);
 
 const testCredentials = {
-  apiUsername: 'authorized_domain',
   apiKey: 'api-key-12345',
 };
 

--- a/test/sendMessage.test.js
+++ b/test/sendMessage.test.js
@@ -11,7 +11,6 @@ const Message = require('../src/data/message.js');
 chai.use(chaiAsPromised);
 
 const testCredentials = {
-  apiUsername: 'authorized_domain',
   apiKey: 'api-key-12345',
 };
 

--- a/test/sendTemplatedMessage.test.js
+++ b/test/sendTemplatedMessage.test.js
@@ -12,7 +12,6 @@ const TemplatedMessage = require('../src/data/templatedMessage.js');
 chai.use(chaiAsPromised);
 
 const testCredentials = {
-  apiUsername: 'authorized_domain',
   apiKey: 'api-key-12345',
 };
 

--- a/test/updateDynamicTemplate.test.js
+++ b/test/updateDynamicTemplate.test.js
@@ -10,7 +10,6 @@ const emailService = require('../src/service/emailService.js');
 chai.use(chaiAsPromised);
 
 const testCredentials = {
-  apiUsername: 'authorized_domain',
   apiKey: 'api-key-12345',
 };
 


### PR DESCRIPTION
The Paubox Email API no longer authenticates with a per-customer
username, so emailService now requires only an apiKey and its base
URL drops the username path segment. A legacy apiUsername passed in
the config is accepted and ignored for backward compatibility.

The API host moves from api.paubox.net to api.paubox.com, and the
Forms API default base URL moves from apx.paubox.com/forms to
api.paubox.com/forms (config.baseURL and FORMS_BASE_URL overrides
unchanged).

Regenerates lib/, updates tests and docs accordingly, and adds
constructor coverage for the apiKey-only configuration.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BNDWKw7Zib6pzsMmxhVV3f