### PR TITLE
chore: reconcile changelog with npm and backfill missing releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,84 @@
 
 All notable changes to this project will be documented in this file.
 
-## v1.4.0 / 2025-08-01
+## Unreleased
 
-- Error handling has changed substantially, for example, now non-200s will be bubbled up as exceptions from Axios instead of swallowed and returning response.data
+Not yet published to npm.
+
+### 🚀 New Features
+
+- Add `formService` for the Paubox Forms API, exported from the package root as `formService(config)` and configurable via `FORMS_API_KEY` / `FORMS_BASE_URL`
+  - Public endpoints, no credential attached: `getForm(formId)`, `submitForm(formId, formData, attachments)`
+  - Form management with a scoped API key (`forms` scope, sent as `Authorization: Bearer <key>`): `listForms`, `getFormById`, `createForm`, `updateForm`, `archiveForm`, `unarchiveForm`, `copyForm`, `getFormStats`
+  - Submissions: `listSubmissions`, `exportSubmissionsCsv`, `exportSubmissionPdf`
+- `emailService` no longer requires `apiUsername` — an API key alone authenticates. A legacy `apiUsername` in the config is accepted and ignored, so existing code keeps working
+
+### ⚠️ Behavior Changes
+
+- The Email API host moves from `api.paubox.net` to `api.paubox.com`, and the base URL drops the per-customer username path segment
+- The Forms API default base URL moves from `apx.paubox.com/forms` to `api.paubox.com/forms`; the `baseURL` config option and `FORMS_BASE_URL` are unchanged as overrides
+
+### 🔒 Hardening
+
+- Validate and encode every caller-supplied value interpolated into a Forms request path. Authenticated endpoints require a UUID; the public `getForm` and `submitForm` encode the segment instead of rejecting it, so any id they accepted before still works
+
+### 📚 Documentation
+
+- Link Paubox Community discussions
+- Update `docs.paubox.com` links to current Mintlify URLs and fix broken `paubox.com` marketing links
+
+## v1.4.2 / 2025-10-10
+
+### 🎉 Enhancements
+
+- Add an automated npm publish workflow triggered on `v*.*.*` tags
+- Bump axios from 1.9.0 to 1.12.0 ([#47](https://github.com/Paubox/paubox-node/pull/47))
+
+## v1.4.1 / 2025-08-01
+
+Supersedes 1.4.0, which was bumped in `package.json` about an hour earlier the
+same day but was never published to npm and never tagged. 1.4.1 is the release
+that actually shipped this work.
+
+### ⚠️ Behavior Changes
+
+- Error handling changed substantially: non-200 responses now bubble up as exceptions from axios instead of being swallowed and returned as `response.data`
+
+### 🎉 Enhancements
+
+- Replace strict type checks that failed under minification with duck typing
+- Loosen the `engines` specifier
+- Bump form-data from 4.0.3 to 4.0.4 ([#44](https://github.com/Paubox/paubox-node/pull/44))
+
+## v1.3.1 / 2025-07-02
+
+### 🚀 New Features
+
+- Add support for custom headers on outbound messages ([#43](https://github.com/Paubox/paubox-node/pull/43))
+
+### 🎉 Enhancements
+
+- Add tests for `sendMessage`, `sendBulkMessages`, and `sendTemplatedMessage`
+
+## v1.3.0 / 2025-06-24
+
+### 🚀 New Features
+
+- Add dynamic template management to `emailService`: `listDynamicTemplates`, `getDynamicTemplate`, `createDynamicTemplate`, `updateDynamicTemplate`, `deleteDynamicTemplate` ([#37](https://github.com/Paubox/paubox-node/pull/37), [#39](https://github.com/Paubox/paubox-node/pull/39))
+- Add `sendTemplatedMessage` and a `templatedMessage` data class ([#40](https://github.com/Paubox/paubox-node/pull/40))
+- Add `sendBulkMessages` for sending several messages in one call ([#36](https://github.com/Paubox/paubox-node/pull/36))
+- Add message validation with clearer errors for malformed input
+
+### 🐛 Fixes
+
+- Fix incorrectly stringified HTTP POST bodies ([#41](https://github.com/Paubox/paubox-node/pull/41))
+
+### 🎉 Enhancements
+
+- Convert all service methods to `async`
+- Add a Babel build step (`src/` compiled to `lib/`), ESLint, and Prettier
+- Add a GitHub Actions workflow running the test suite
+- Bump axios to 1.9.0 ([#38](https://github.com/Paubox/paubox-node/pull/38)) and upgrade mocha ([#42](https://github.com/Paubox/paubox-node/pull/42))
 
 ## v1.2.5 / 2021-04-28
 


### PR DESCRIPTION
Phase 1 of the SDK release automation plan for this repo. No release is cut and no version number is consumed.

## What was actually wrong

The plan had this repo down as "already consistent at 1.4.2, add nothing." The current version *is* consistent — npm `1.4.2`, `package.json` `1.4.2`, and tag `v1.4.2` all agree, so `package.json` is untouched here. But the history around it wasn't.

**`1.4.1` was on npm with no tag.** Published 2025-08-01, one minute after `7ce956e` (titled just `1.4.1`) set `package.json` to 1.4.1.

**`1.4.0` was never published.** `df89b92` bumped to 1.4.0 about an hour earlier the same day and was superseded by 1.4.1 before anything shipped. It is not on npm and never was. The changelog's `## v1.4.0 / 2025-08-01` heading described work that reached users as 1.4.1.

**Two malformed tags.** `1.4.2` with no `v` prefix — and pointing at `f76eba5`, a different commit than `v1.4.2` — plus `v1.2.5-corrected`, which is not semver and *matched `publish.yml`'s `v*.*.*` trigger*.

**The changelog had two entries for twelve npm versions.**

## Tag changes (already applied)

| Action | Tag | Commit |
|---|---|---|
| Created | `v1.4.1` | `7ce956e` |
| Deleted | `1.4.2` (no `v`) | was `f76eba5` |
| Deleted | `v1.2.5-corrected` | was `3a9e462` |

Tags are now contiguous and uniformly bare `vX.Y.Z` from `v1.2.0` to `v1.4.2`. (`1.0.0` and `1.1.0` are on npm from 2018–2019 and have never had tags; left alone as pre-history.)

Creating `v1.4.1` did **not** trigger a publish — `publish.yml` was added in `46ff681` for v1.4.2, so it does not exist at `7ce956e` and GitHub had no workflow to run at that ref. npm `1.4.1` is untouched, still showing its original 2025-08-01 timestamp. Worth knowing before retroactively tagging any repo where the publish workflow predates the commit being tagged.

## Changelog changes

- `v1.4.0` relabelled to `v1.4.1`, with a note explaining the supersession
- Backfilled `v1.3.0`, `v1.3.1`, and `v1.4.2` from git history
- Staged the unreleased Forms API and auth work under `Unreleased`
- Headings kept at H2 — release-please finds its insertion point with `/\n###? v?[0-9[]/`, which an H1 heading does not match

## What happens next

Phase 2 adds release-please seeded at `1.4.2`. Verified with release-please's own parser that it will propose **1.5.0** from the single `feat:` in range, with no breaking changes. Five of the eleven commits since `v1.4.2` are non-conventional and get dropped silently — including the entire Forms API introduction and the `apiUsername` removal — which is why the `Unreleased` notes exist.

Note the `apiUsername` removal was checked specifically for breakage: a legacy `apiUsername` in the config is accepted and ignored, so it is a minor, not a major.

## Test plan

- [ ] CI green
- [ ] `git ls-remote --tags origin` shows a contiguous `v1.2.0`–`v1.4.2` with no malformed entries
- [ ] npm still shows `1.4.2` as latest and `1.4.1` with its original publish timestamp